### PR TITLE
Handle 'RC' as version status

### DIFF
--- a/src/main/java/io/jenkins/plugins/dotnet/data/Downloads.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/data/Downloads.java
@@ -206,8 +206,17 @@ public final class Downloads extends DownloadService.Downloadable {
       }
       {
         final Object value = json.get("status");
-        if (value instanceof String)
-          this.status = Enum.valueOf(Status.class, (String) value);
+        if (value instanceof String) {
+          Status status;
+          try {
+            status = Enum.valueOf(Status.class, (String) value);
+          }
+          catch (Throwable t) {
+            Downloads.LOGGER.warning(String.format("Encountered an unsupported version status ('%s').", value));
+            status = Status.UNKNOWN;
+          }
+          this.status = status;
+        }
         else
           this.status = Status.UNKNOWN;
       }
@@ -241,6 +250,9 @@ public final class Downloads extends DownloadService.Downloadable {
       /** This is a preview of the next version of .NET. */
       PREVIEW,
 
+      /** This is release candidate for the next version of .NET. */
+      RC,
+
       /** The status of the version is unknown. */
       UNKNOWN,
 
@@ -264,6 +276,8 @@ public final class Downloads extends DownloadService.Downloadable {
             return Messages.Downloads_Version_Status_Maintenance();
           case PREVIEW:
             return Messages.Downloads_Version_Status_Preview();
+          case RC:
+            return Messages.Downloads_Version_Status_ReleaseCandidate();
           case UNKNOWN:
             return Messages.Downloads_Version_Status_Unknown();
           default:

--- a/src/main/resources/io/jenkins/plugins/dotnet/DotNetSDKInstaller/help-includePreview.html
+++ b/src/main/resources/io/jenkins/plugins/dotnet/DotNetSDKInstaller/help-includePreview.html
@@ -1,4 +1,4 @@
 <div>
   When checked, preview releases will be included in the list of releases.
-  Note that preview <em>versions</em> will <strong>always</strong> be shown (because unlike releases, versions can change status.
+  Note that preview <em>versions</em> will <strong>always</strong> be shown (because unlike releases, versions can change status).
 </div>

--- a/src/main/resources/io/jenkins/plugins/dotnet/data/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/data/Messages.properties
@@ -15,6 +15,7 @@ Downloads.Version.Status.EOL=End of Life
 Downloads.Version.Status.LTS=Long-Term Support
 Downloads.Version.Status.Maintenance=Maintenance
 Downloads.Version.Status.Preview=Preview
+Downloads.Version.Status.ReleaseCandidate=Release Candidate
 Downloads.Version.Status.Unknown=Status Unknown
 
 # Data: Framework Monikers

--- a/src/main/resources/io/jenkins/plugins/dotnet/data/Messages_fr.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/data/Messages_fr.properties
@@ -15,6 +15,7 @@ Downloads.Version.Status.EOL=Fin de vie
 Downloads.Version.Status.LTS=Soutien à long terme
 Downloads.Version.Status.Maintenance=Entretien
 Downloads.Version.Status.Preview=Aperçu
+Downloads.Version.Status.ReleaseCandidate=Release Candidate
 Downloads.Version.Status.Unknown=Statut inconnu
 
 # Data: Framework Monikers

--- a/src/main/resources/io/jenkins/plugins/dotnet/data/Messages_nl.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/data/Messages_nl.properties
@@ -15,6 +15,7 @@ Downloads.Version.Status.EOL=End of life
 Downloads.Version.Status.LTS=Long-term support
 Downloads.Version.Status.Maintenance=Maintenance
 Downloads.Version.Status.Preview=Preview
+Downloads.Version.Status.ReleaseCandidate=Release Candidate
 Downloads.Version.Status.Unknown=Status onbekend
 
 # Data: Framework Monikers


### PR DESCRIPTION
The first .NET 5.0 release candidate is available, and this uses a new `RC` status, breaking the download data.
This also maps all future new statuses to `UNKNOWN`, logging a warning.