### PR TITLE
Avoid duplicate console filtering

### DIFF
--- a/src/main/java/io/jenkins/plugins/dotnet/console/DiagnosticFilter.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/console/DiagnosticFilter.java
@@ -7,6 +7,7 @@ import hudson.model.Run;
 import io.jenkins.plugins.dotnet.DotNetUtils;
 
 import java.io.OutputStream;
+import java.io.PrintStream;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 
@@ -28,6 +29,8 @@ public final class DiagnosticFilter extends ConsoleLogFilter implements Serializ
   @Override
   @NonNull
   public OutputStream decorateLogger(@Nullable Run build, @NonNull OutputStream logger) {
+    if (logger instanceof DiagnosticScanner)
+      return logger;
     return new DiagnosticScanner(logger, StandardCharsets.UTF_8, this.diagnosticNote);
   }
 

--- a/src/main/java/io/jenkins/plugins/dotnet/console/DiagnosticNote.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/console/DiagnosticNote.java
@@ -80,6 +80,7 @@ public final class DiagnosticNote extends ConsoleNote<Object> {
   @SuppressWarnings("rawtypes")
   @Override
   public ConsoleAnnotator annotate(@NonNull Object context, MarkupText text, int charPos) {
+    // FIXME: This logic should probably avoid adding markup to a line that already includes it.
     final String t = text.getText().replaceAll("\r?\n$", "");
     {
       Matcher m = DiagnosticNote.RE_ERROR_LINE.matcher(t);

--- a/src/main/java/io/jenkins/plugins/dotnet/console/DiagnosticScanner.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/console/DiagnosticScanner.java
@@ -142,7 +142,11 @@ public final class DiagnosticScanner extends LineTransformationOutputStream {
       if (m.matches())
         this.warnings = Integer.parseInt(m.group(1));
     }
-    if (DiagnosticNote.appliesTo(line))
+    // FIXME: Sadly, this can't usually correctly detect that another DiagnosticScanner is at work. For example, when a command is
+    // FIXME: used inside a wrapper, the decorator added by the wrapper gets wrapped in a PrintStream before being passed to the
+    // FIXME: command, making it unrecognizable.
+    // FIXME: This _could_ look for an encoded DiagnosticNote in the line bytes, but that currently doesn't seem worth it.
+    if (!(this.out instanceof DiagnosticScanner) && DiagnosticNote.appliesTo(line))
       this.out.write(this.diagnosticNote);
     this.out.write(lineBytes, 0, lineLength);
   }


### PR DESCRIPTION
This only avoids excess decoration in cases where .NET wrappers are (directly) nested.
Avoiding it in other cases (as with a .NET command used inside a .NET wrapper) seems to be considerably more difficult.