### PR TITLE
Make use of the fix for JENKINS-62572

### DIFF
--- a/src/main/java/io/jenkins/plugins/dotnet/data/Downloads.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/data/Downloads.java
@@ -608,8 +608,7 @@ public final class Downloads extends DownloadService.Downloadable {
    */
   @NonNull
   public static synchronized Downloads getInstance() {
-    // JENKINS-62572: would be simpler to pass just the class
-    final DownloadService.Downloadable instance = DownloadService.Downloadable.get(Downloads.class.getName().replace('$', '.'));
+    final DownloadService.Downloadable instance = DownloadService.Downloadable.get(Downloads.class);
     if (instance instanceof Downloads)
       return ((Downloads) instance).loadData();
     else { // No such downloadable (should be impossible).

--- a/src/main/java/io/jenkins/plugins/dotnet/data/Framework.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/data/Framework.java
@@ -94,8 +94,7 @@ public final class Framework extends DownloadService.Downloadable {
    */
   @NonNull
   public static synchronized Framework getInstance() {
-    // JENKINS-62572: would be simpler to pass just the class
-    final DownloadService.Downloadable instance = DownloadService.Downloadable.get(Framework.class.getName());
+    final DownloadService.Downloadable instance = DownloadService.Downloadable.get(Framework.class);
     if (instance instanceof Framework)
       return ((Framework) instance).loadMonikers();
     else { // No such downloadable (should be impossible).

--- a/src/main/java/io/jenkins/plugins/dotnet/data/Runtime.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/data/Runtime.java
@@ -94,8 +94,7 @@ public final class Runtime extends DownloadService.Downloadable {
    */
   @NonNull
   public static synchronized Runtime getInstance() {
-    // JENKINS-62572: would be simpler to pass just the class
-    final DownloadService.Downloadable instance = DownloadService.Downloadable.get(Runtime.class.getName());
+    final DownloadService.Downloadable instance = DownloadService.Downloadable.get(Runtime.class);
     if (instance instanceof Runtime)
       return ((Runtime) instance).loadIdentifiers();
     else { // No such downloadable (should be impossible).


### PR DESCRIPTION
This enables passing a class to `DownloadService.Downloadable.get()`, making for slightly cleaner code.
