### PR TITLE
Delete the IntelliJ .iml file

### DIFF
--- a/.idea/dotnet-sdk-plugin.iml
+++ b/.idea/dotnet-sdk-plugin.iml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="JAVA_MODULE" version="4" />


### PR DESCRIPTION
Apparently, it doesn't need module files for Maven projects anymore.
