### PR TITLE
JENKINS-66120: Set `$DOTNET_ROOT` to the SDK home

### DIFF
--- a/src/main/java/io/jenkins/plugins/dotnet/DotNetSDK.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/DotNetSDK.java
@@ -35,8 +35,17 @@ public final class DotNetSDK extends ToolInstallation implements NodeSpecific<Do
 
   private static final long serialVersionUID = 1834789641052956539L;
 
-  /** The environment variable that will be set to the full path to the SDK. */
+  /**
+   * An environment variable that will be set to the full path to the SDK (backward compatibility).
+   *
+   * @deprecated Use {@link #ROOT_ENVIRONMENT_VARIABLE} instead; that environment variable is also used by the SDK itself.
+   */
+  @Deprecated
+  @SuppressWarnings("DeprecatedIsStillUsed")
   public static final String HOME_ENVIRONMENT_VARIABLE = "DOTNET_SDK_JENKINS_TOOL_HOME";
+
+  /** The environment variable that will be set to the full path to the SDK (used by the SDK in some cases). */
+  public static final String ROOT_ENVIRONMENT_VARIABLE = "DOTNET_ROOT";
 
   /**
    * Creates a new .NET SDK installation.
@@ -47,7 +56,6 @@ public final class DotNetSDK extends ToolInstallation implements NodeSpecific<Do
   public DotNetSDK(@NonNull String name, @NonNull String home) {
     super(name, home, Collections.emptyList());
   }
-
 
   /**
    * Creates a new .NET SDK installation.
@@ -104,10 +112,15 @@ public final class DotNetSDK extends ToolInstallation implements NodeSpecific<Do
    */
   @Override
   public void buildEnvVars(@NonNull EnvVars env) {
-    env.put(DotNetSDK.HOME_ENVIRONMENT_VARIABLE, this.getHome());
-    env.put("PATH+DOTNET", this.getHome());
-    if (this.telemetryOptOut)
+    { // Store the home location in the environment, and add it to PATH
+      final String home = this.getHome();
+      env.put(DotNetSDK.HOME_ENVIRONMENT_VARIABLE, home);
+      env.put(DotNetSDK.ROOT_ENVIRONMENT_VARIABLE, home);
+      env.put("PATH+DOTNET", home);
+    }
+    if (this.telemetryOptOut) {
       env.put("DOTNET_CLI_TELEMETRY_OPTOUT", "1");
+    }
   }
 
   /**

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/Command.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/Command.java
@@ -87,7 +87,7 @@ public class Command extends Builder implements SimpleBuildStep {
     else {
       final String basename = DotNetSDK.getExecutableFileName(launcher);
       {
-        final String home = Util.fixEmptyAndTrim(env.get(DotNetSDK.HOME_ENVIRONMENT_VARIABLE, ""));
+        final String home = Util.fixEmptyAndTrim(env.get(DotNetSDK.ROOT_ENVIRONMENT_VARIABLE, ""));
         if (home != null) // construct the full remote path
           executable = new FilePath(launcher.getChannel(), home).child(basename).absolutize().getRemote();
         else // will have to rely on the system's PATH


### PR DESCRIPTION
It turns out the SDK uses this in some cases (e.g. when dealing with .NET tools).
As such, the environment variable previously being set to the SDK home (`$DOTNET_SDK_JENKINS_TOOL_HOME`) is now considered
deprecated.
