### PR TITLE
Add the --vulnerable option for list package.

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -6,8 +6,14 @@
         <sourceOutputDir name="target/generated-sources/annotations" />
         <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
         <outputRelativeToContentRoot value="true" />
+        <module name="dotnet-sdk" />
         <module name="dotnet-sdk-plugin" />
       </profile>
     </annotationProcessing>
+  </component>
+  <component name="JavacSettings">
+    <option name="ADDITIONAL_OPTIONS_OVERRIDE">
+      <module name="dotnet-sdk" options="-parameters" />
+    </option>
   </component>
 </project>

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/ListPackage.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/ListPackage.java
@@ -59,13 +59,16 @@ public final class ListPackage extends Command {
     args.add("package");
     args.addFlag("deprecated", this.deprecated);
     args.addFlag("outdated", this.outdated);
+    args.addFlag("vulnerable", this.vulnerable);
     args.addOptions("framework", this.frameworks);
     args.addFlag("include-transitive", this.includeTransitive);
     args.addOption('v', this.verbosity);
-    if (this.outdated || this.deprecated) {
+    if (this.outdated) {
       args.addFlag("include-prerelease", this.includePrerelease);
       args.addFlag("highest-minor", this.highestMinor);
       args.addFlag("highest-patch", this.highestPatch);
+    }
+    if (this.deprecated || this.outdated || this.vulnerable) {
       args.addOption("config", this.config);
       args.addOptions("source", this.sources);
     }
@@ -98,7 +101,7 @@ public final class ListPackage extends Command {
   private boolean deprecated;
 
   /**
-   * Determines whether or not deprecated packages should be shown.
+   * Determines whether deprecated packages should be shown.
    *
    * @return {@code true} if deprecated packages should be shown; {@code false} otherwise.
    */
@@ -107,7 +110,7 @@ public final class ListPackage extends Command {
   }
 
   /**
-   * Determines whether or not deprecated packages should be shown.
+   * Determines whether deprecated packages should be shown.
    *
    * @param deprecated {@code true} to show deprecated packages; {@code false} otherwise.
    */
@@ -183,7 +186,7 @@ public final class ListPackage extends Command {
   private boolean highestMinor;
 
   /**
-   * Determines whether or not to consider only packages where at most the minor version has changed.
+   * Determines whether to consider only packages where at most the minor version has changed.
    *
    * @return {@code true} if only packages where at most the minor version has changed are considered; {@code false} otherwise.
    */
@@ -192,7 +195,7 @@ public final class ListPackage extends Command {
   }
 
   /**
-   * Determines whether or not to consider only packages where at most the minor version has changed.
+   * Determines whether to consider only packages where at most the minor version has changed.
    *
    * @param highestMinor {@code true} to only consider packages where at most the minor version has changed; {@code false}
    *                     otherwise.
@@ -205,7 +208,7 @@ public final class ListPackage extends Command {
   private boolean highestPatch;
 
   /**
-   * Determines whether or not to consider only packages where at most the patch version has changed.
+   * Determines whether to consider only packages where at most the patch version has changed.
    *
    * @return {@code true} if only packages where at most the patch version has changed are considered; {@code false} otherwise.
    */
@@ -214,7 +217,7 @@ public final class ListPackage extends Command {
   }
 
   /**
-   * Determines whether or not to consider only packages where at most the patch version has changed.
+   * Determines whether to consider only packages where at most the patch version has changed.
    *
    * @param highestPatch {@code true} to only consider packages where at most the patch version has changed; {@code false}
    *                     otherwise.
@@ -227,7 +230,7 @@ public final class ListPackage extends Command {
   private boolean includePrerelease;
 
   /**
-   * Determines whether or not to consider prerelease packages.
+   * Determines whether to consider prerelease packages.
    *
    * @return {@code true} if prerelease packages are considered; {@code false} otherwise.
    */
@@ -236,7 +239,7 @@ public final class ListPackage extends Command {
   }
 
   /**
-   * Determines whether or not to consider prerelease packages.
+   * Determines whether to consider prerelease packages.
    *
    * @param includePrerelease {@code true} to consider prerelease packages; {@code false} otherwise.
    */
@@ -248,7 +251,7 @@ public final class ListPackage extends Command {
   private boolean includeTransitive;
 
   /**
-   * Determines whether or not to show transitive dependencies.
+   * Determines whether to show transitive dependencies.
    *
    * @return {@code true} if transitive dependencies are shown; {@code false} otherwise.
    */
@@ -257,7 +260,7 @@ public final class ListPackage extends Command {
   }
 
   /**
-   * Determines whether or not to show transitive dependencies.
+   * Determines whether to show transitive dependencies.
    *
    * @param includeTransitive {@code true} to show transitive dependencies; {@code false} otherwise.
    */
@@ -269,7 +272,7 @@ public final class ListPackage extends Command {
   private boolean outdated;
 
   /**
-   * Determines whether or not outdated packages should be shown.
+   * Determines whether outdated packages should be shown.
    *
    * @return {@code true} if outdated packages should be shown; {@code false} otherwise.
    */
@@ -278,7 +281,7 @@ public final class ListPackage extends Command {
   }
 
   /**
-   * Determines whether or not outdated packages should be shown.
+   * Determines whether outdated packages should be shown.
    *
    * @param outdated {@code true} to show outdated packages; {@code false} otherwise.
    */
@@ -393,6 +396,27 @@ public final class ListPackage extends Command {
   @DataBoundSetter
   public void setVerbosity(@CheckForNull String verbosity) {
     this.verbosity = Util.fixEmptyAndTrim(verbosity);
+  }
+
+  private boolean vulnerable;
+
+  /**
+   * Determines whether packages with known vulnerabilities should be shown.
+   *
+   * @return {@code true} if packages with known vulnerabilities should be shown; {@code false} otherwise.
+   */
+  public boolean isVulnerable() {
+    return this.vulnerable;
+  }
+
+  /**
+   * Determines whether packages with known vulnerabilities should be shown.
+   *
+   * @param vulnerable {@code true} to show packages with known vulnerabilities; {@code false} otherwise.
+   */
+  @DataBoundSetter
+  public void setVulnerable(boolean vulnerable) {
+    this.vulnerable = vulnerable;
   }
 
   //endregion

--- a/src/main/resources/io/jenkins/plugins/dotnet/Messages_fr.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/Messages_fr.properties
@@ -4,31 +4,31 @@ DotNetSDK.GlobalJson.CreationDone=Création de «global.json» pour forcer la versi
 DotNetSDK.GlobalJson.CreationFailed=Échec à créer «global.json» pour forcer la version exacte «{1}» pour SDK .NET «{0}»: {2}
 DotNetSDK.GlobalJson.DeletionDone=Fichier «{0}» a été supprimé.
 DotNetSDK.GlobalJson.DeletionFailed=Échec de la suppression du fichier «{0}»: {1}
-DotNetSDK.GlobalJson.MultiSdk=Le répertoire d’installation contient plusieurs arborescences SDK (y compris «{0}» et «{1}»).
-DotNetSDK.GlobalJson.NoHome=Pas de répertoire d’installation disponible.
-DotNetSDK.GlobalJson.NoSdk=Le répertoire d’installation n’a pas de sous-répertoire «sdk».
+DotNetSDK.GlobalJson.MultiSdk=Le répertoire d'installation contient plusieurs arborescences SDK (y compris «{0}» et «{1}»).
+DotNetSDK.GlobalJson.NoHome=Pas de répertoire d'installation disponible.
+DotNetSDK.GlobalJson.NoSdk=Le répertoire d'installation n'a pas de sous-répertoire «sdk».
 DotNetSDK.GlobalJson.NoVersion=Impossible de déterminer la version exacte pour SDK .NET «{0}»: {1}
-DotNetSDK.Home.NoExecutable=Aucun programme «dotnet» n’est présent
-DotNetSDK.Home.NotExecutable=Un programme «dotnet» est présent mais il n’est pas exécutable
-DotNetSDK.Home.NoSdkSubdir=Aucun sous-répertoire «sdk» n’est présent
-DotNetSDK.Home.NoSharedNetCoreSubdir=Aucun sous-répertoire «shared/Microsoft.NETCore.App» n’est présent
-DotNetSDK.NoExecutable=Impossible de trouver l’exécutable «{1}» pour le SDK «{0}»
-DotNetSDK.NoHome=Pas de répertoire d’installation disponible pour SDK .NET «{0}»
-DotNetSDK.NoNode=Impossible de trouver l’exécutable «dotnet» car le nœud semble être hors ligne
+DotNetSDK.Home.NoExecutable=Aucun programme «dotnet» n'est présent
+DotNetSDK.Home.NotExecutable=Un programme «dotnet» est présent mais il n'est pas exécutable
+DotNetSDK.Home.NoSdkSubdir=Aucun sous-répertoire «sdk» n'est présent
+DotNetSDK.Home.NoSharedNetCoreSubdir=Aucun sous-répertoire «shared/Microsoft.NETCore.App» n'est présent
+DotNetSDK.NoExecutable=Impossible de trouver l'exécutable «{1}» pour le SDK «{0}»
+DotNetSDK.NoHome=Pas de répertoire d'installation disponible pour SDK .NET «{0}»
+DotNetSDK.NoNode=Impossible de trouver l'exécutable «dotnet» car le nœud semble être hors ligne
 DotNetSDK.UnknownSDK=Aucun SDK .NET trouvé nommé «{0}»
 
 # Tool Installer: .NET SDK Installer
 DotNetSDKInstaller.DisplayName=Installer à partir de microsoft.com
 DotNetSDKInstaller.Installing=Téléchargement et extraction de {0} en {1} sur {2}...
 DotNetSDKInstaller.InvalidPlatform=Pas une plate-forme valide pour SDK {2} de {0}, release {1}
-DotNetSDKInstaller.InvalidRelease="«{0}» n’est pas un release valide pour {1}
-DotNetSDKInstaller.InvalidSdk=«{0}» n’est pas un SDK valide pour {1}, release {2}
-DotNetSDKInstaller.InvalidVersion=«{0}» n’est pas une version .NET valide
+DotNetSDKInstaller.InvalidRelease="«{0}» n'est pas un release valide pour {1}
+DotNetSDKInstaller.InvalidSdk=«{0}» n'est pas un SDK valide pour {1}, release {2}
+DotNetSDKInstaller.InvalidVersion=«{0}» n'est pas une version .NET valide
 DotNetSDKInstaller.NotSelected=(Aucune sélection faite)
-DotNetSDKInstaller.ReleaseRequired=Sélectionnez d’abord un release
+DotNetSDKInstaller.ReleaseRequired=Sélectionnez d'abord un release
 DotNetSDKInstaller.Required=Une sélection est requise
-DotNetSDKInstaller.SdkRequired=Sélectionnez d’abord un SDK
-DotNetSDKInstaller.VersionRequired=Sélectionnez d’abord une version .NET
+DotNetSDKInstaller.SdkRequired=Sélectionnez d'abord un SDK
+DotNetSDKInstaller.VersionRequired=Sélectionnez d'abord une version .NET
 
 # Build Wrappper
 DotNetWrapper.DisplayName=Utiliser .NET

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/ListPackage/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/ListPackage/config.jelly
@@ -27,6 +27,10 @@
       <f:checkbox/>
     </f:entry>
 
+    <f:entry title="${%Show Packages With Known Vulnerabilities}" field="vulnerable">
+      <f:checkbox/>
+    </f:entry>
+
     <f:entry title="${%Include Pre-Release Versions}" field="includePrerelease">
       <f:checkbox/>
     </f:entry>

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/ListPackage/config_fr.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/ListPackage/config_fr.properties
@@ -3,6 +3,7 @@ Frameworks=Frameworks
 Include\ Transitive\ Packages=Inclure les packages transitifs
 Show\ Deprecated\ Packages=Afficher les packages rappelés
 Show\ Outdated\ Packages=Afficher les packages désuets
+Show\ Packages\ With\ Known\ Vulnerabilities=Afficher les packages présentant des vulnérabilités connues
 Include\ Pre-Release\ Versions=Inclure des versions préliminaires
 NuGet\ Config\ to\ Use=Configuration NuGet à utiliser
 NuGet\ Sources\ to\ Search\ for\ Updates=Sources NuGet à utiliser

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/ListPackage/config_nl.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/ListPackage/config_nl.properties
@@ -3,6 +3,7 @@ Frameworks=Frameworks
 Include\ Transitive\ Packages=Toon ook transitieve pakketten
 Show\ Deprecated\ Packages=Toon afgeschafte pakketten
 Show\ Outdated\ Packages=Toon verouderde pakketten
+Show\ Packages\ With\ Known\ Vulnerabilities=Toon pakketten met gekende veiligheidsproblemen
 Include\ Pre-Release\ Versions=Toon ook pre-releaseversies
 NuGet\ Config\ to\ Use=NuGet configuratiebestand
 NuGet\ Sources\ to\ Search\ for\ Updates=NuGet bronnen voor updates

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/ListPackage/help-config.html
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/ListPackage/help-config.html
@@ -1,5 +1,5 @@
 <div>
   <!-- Adapted From: https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-list-package#options -->
   Configuration file containing the NuGet sources to use when searching for newer packages.
-  Applies only when asked to show deprecated or outdated packages.
+  Requires the <code>--outdated</code>, <code>--deprecated</code> or <code>--vulnerable</code> option.
 </div>

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/ListPackage/help-deprecated.html
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/ListPackage/help-deprecated.html
@@ -1,6 +1,6 @@
 <div>
   <!-- Not Currently Documented Here: https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-list-package#options -->
-  Lists packages that have been deprecated.
+  Lists packages that have been deprecated. Cannot be combined with <code>--vulnerable</code> or <code>--outdated</code> options.
 </div>
 <br/>
 <div>

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/ListPackage/help-highestMinor.html
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/ListPackage/help-highestMinor.html
@@ -1,5 +1,5 @@
 <div>
   <!-- Copied From: https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-list-package#options -->
-  Considers only the packages with a matching major version number when searching for newer packages.
-  Applies only when asked to show deprecated or outdated packages.
+  Considers only the packages with a matching major version number when searching for newer packages. Requires the
+  <code>--outdated</code> option.
 </div>

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/ListPackage/help-highestPatch.html
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/ListPackage/help-highestPatch.html
@@ -1,5 +1,5 @@
 <div>
   <!-- Copied From: https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-list-package#options -->
-  Considers only the packages with a matching major and minor version numbers when searching for newer packages.
-  Applies only when asked to show deprecated or outdated packages.
+  Considers only the packages with a matching major and minor version numbers when searching for newer packages. Requires the
+  <code>--outdated</code> option.
 </div>

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/ListPackage/help-includePrerelease.html
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/ListPackage/help-includePrerelease.html
@@ -1,5 +1,4 @@
 <div>
   <!-- Copied From: https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-list-package#options -->
-  Considers packages with prerelease versions when searching for newer packages.
-  Applies only when asked to show deprecated or outdated packages.
+  Considers packages with prerelease versions when searching for newer packages. Requires the <code>--outdated</code> option.
 </div>

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/ListPackage/help-outdated.html
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/ListPackage/help-outdated.html
@@ -1,4 +1,4 @@
 <div>
   <!-- Copied From: https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-list-package#options -->
-  Lists packages that have newer versions available.
+  Lists packages that have newer versions. Cannot be combined with <code>--deprecated</code> or <code>--vulnerable</code> options.
 </div>

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/ListPackage/help-sourcesString.html
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/ListPackage/help-sourcesString.html
@@ -1,5 +1,5 @@
 <div>
   <!-- Copied From: https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-list-package#options -->
-  The NuGet sources to use when searching for newer packages.
-  Applies only when asked to show deprecated or outdated packages.
+  The NuGet sources to use when searching for packages.
+  Requires the <code>--outdated</code>>, <code>--deprecated</code>> or <code>--vulnerable</code>> option.
 </div>

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/ListPackage/help-vulnerable.html
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/ListPackage/help-vulnerable.html
@@ -1,0 +1,8 @@
+<div>
+  <!-- Copied From: https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-list-package#options -->
+  Lists packages that have known vulnerabilities. Cannot be combined with <code>--deprecated</code> or <code>--outdated</code>
+  options.
+</div>
+<div>
+  <em><strong>Available since:</strong> .NET Core SDK 5.0.200</em>
+</div>

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/Messages_fr.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/Messages_fr.properties
@@ -1,5 +1,5 @@
 Command.DefaultSDK=(Défaut)
-Command.ExecutionFailed=L’exécution de la commande a échoué
+Command.ExecutionFailed=L'exécution de la commande a échoué
 Command.MoreOptions=Options additionelles
 Command.Verbosity.Default=(Défaut)
 Command.Verbosity.Quiet=Silencieux (q)
@@ -8,15 +8,15 @@ Command.Verbosity.Normal=Normale (n)
 Command.Verbosity.Detailed=Detaillé (d)
 Command.Verbosity.Diagnostic=Diagnostique (diag)
 
-DotNetArguments.StringCredentialNotFound=Aucune information d’identification trouvée avec identifiant «{0}».
+DotNetArguments.StringCredentialNotFound=Aucune information d'identification trouvée avec identifiant «{0}».
 
 ListPackage.DisplayName=.NET: Afficher les dépendances (list package)
-ListPackage.EitherDeprecatedOrOutdated=Impossible d’afficher les paquets rappelés et désuets en même temps
-ListPackage.OnlyForPackageUpdateSearch=N’utilisé que pendant l’affichage des paquets rappelés ou désuets
+ListPackage.EitherDeprecatedOrOutdated=Impossible d'afficher les paquets rappelés et désuets en même temps
+ListPackage.OnlyForPackageUpdateSearch=N'utilisé que pendant l'affichage des paquets rappelés ou désuets
 
 MSBuild.Build.DisplayName=.NET: Générer un projet (build)
 
-MSBuild.Clean.DisplayName=.NET: Nettoyer la sortie d’un projet (clean)
+MSBuild.Clean.DisplayName=.NET: Nettoyer la sortie d'un projet (clean)
 
 MSBuild.Command.BadProperties=Échec à charger les propriétés MSBuild configurées.
 MSBuild.Command.InvalidProperties=Spécification incorrecte des propriétés MSBuild
@@ -31,13 +31,13 @@ MSBuild.Publish.Yes=Oui
 MSBuild.Test.BadRunSettings=Échec à charger les arguments RunSettings configurés.
 MSBuild.Test.DisplayName=.NET: Exécuter des tests unitaires (test)
 MSBuild.Test.InvalidRunSettings=Spécification incorrecte des arguments RunSettings
-MSBuild.Test.InvalidTimeout=Le délai d’attente ne peut pas être négatif
+MSBuild.Test.InvalidTimeout=Le délai d'attente ne peut pas être négatif
 
 NuGet.Delete.DisplayName=.NET: Supprimer/Délister un package NuGet (nuget delete)
 NuGet.Delete.InvalidPackageName=Spécification incorrecte du nom du package.
 NuGet.Delete.InvalidPackageVersion=Spécification incorrecte de la version du package.
-NuGet.Delete.PackageVersionWithoutName=Une spécification de version de package est ignorée lorsqu’aucun nom de package n’a été spécifié.
-NuGet.Delete.PackageNameWithoutVersion=Une spécification de version de package est requise lorsqu’un nom de package a été spécifié.
+NuGet.Delete.PackageVersionWithoutName=Une spécification de version de package est ignorée lorsqu'aucun nom de package n'a été spécifié.
+NuGet.Delete.PackageNameWithoutVersion=Une spécification de version de package est requise lorsqu'un nom de package a été spécifié.
 
 NuGet.Locals.DisplayName=.NET: Supprimer/Afficher les ressources NuGet locales (nuget locals)
 NuGet.Locals.InvalidCacheLocation=Emplacement de cache "{0}" non valide; valeurs valides sont «all», «global-packages», «http-cache» et «temp».

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/Messages_nl.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/Messages_nl.properties
@@ -53,4 +53,4 @@ NuGet.Push.DisplayName=.NET: NuGet pakket publiceren (nuget push)
 
 Restore.DisplayName=.NET: Afhankelijkheden herstellen (restore)
 
-Tool.Restore.DisplayName=.NET: Lokale hulpprogramma’s herstellen (tool restore)
+Tool.Restore.DisplayName=.NET: Lokale hulpprogramma's herstellen (tool restore)

--- a/src/main/resources/io/jenkins/plugins/dotnet/console/Messages_fr.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/console/Messages_fr.properties
@@ -1,3 +1,3 @@
 # Console Output Scanner
 DiagnosticScanner.CompletionMessage=Commande .NET complétée - <!>Code de sortie: {0}
-DiagnosticScanner.CompletionMessageFailed=L’écriture du message d’achèvement a échoué
+DiagnosticScanner.CompletionMessageFailed=L'écriture du message d'achèvement a échoué

--- a/src/main/resources/io/jenkins/plugins/dotnet/data/Messages_fr.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/data/Messages_fr.properties
@@ -19,11 +19,11 @@ Downloads.Version.Status.ReleaseCandidate=Release Candidate
 Downloads.Version.Status.Unknown=Statut inconnu
 
 # Data: Framework Monikers
-Framework.Invalid=«{0}» n’est pas un surnom de framework .NET valide
+Framework.Invalid=«{0}» n'est pas un surnom de framework .NET valide
 Framework.LoadFailed=Échec à charger les surnoms de framework .NET.
 Framework.NoData=Aucun surnom de framework .NET trouvé.
 
 # Data: Runtime Identifiers
-Runtime.Invalid=«{0}» n’est pas un identifiant de runtime .NET valide
+Runtime.Invalid=«{0}» n'est pas un identifiant de runtime .NET valide
 Runtime.LoadFailed=Échec à charger le catalogue RID.
 Runtime.NoData=Le catalogue RID est vide.


### PR DESCRIPTION
This is available starting from .NET SDK 5.0.200.

The help pages for the various options for `list package` have been updated as well.

The quotes present in the Messages bundles were corrected; they were proper single quotes, but the files need to be ISO-8859-1, so they are now plain apostrophes.
