### PR TITLE
Create links for SYSLIB diagnostics too

### DIFF
--- a/src/main/java/io/jenkins/plugins/dotnet/console/DiagnosticNote.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/console/DiagnosticNote.java
@@ -44,6 +44,7 @@ public final class DiagnosticNote extends ConsoleNote<Object> {
     DiagnosticNote.MESSAGE_PREFIX_URLS.put("CS", "https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/"); // C#
     DiagnosticNote.MESSAGE_PREFIX_URLS.put("FS", "https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/compiler-messages/"); // F#
     DiagnosticNote.MESSAGE_PREFIX_URLS.put("NU", "https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/"); // NuGet
+    DiagnosticNote.MESSAGE_PREFIX_URLS.put("SYSLIB", "https://aka.ms/dotnet-warnings/"); // .NET 6
   }
 
   /** Regular expression for the 'error' label. */


### PR DESCRIPTION
This will link the `SYSLIBxxx` warnings produced by the .NET 6 SDK to the appropriate Microsoft page.
Example: [SYSLIB0014](https://aka.ms/dotnet-warnings/SYSLIB0014).