### PR TITLE
Update the minimum Jenkins version to 2.289.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <properties>
     <revision>1.1.3</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.249.1</jenkins.version>
+    <jenkins.version>2.289.1</jenkins.version>
     <java.level>8</java.level>
     <useBeta>true</useBeta>
   </properties>
@@ -42,7 +42,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.19</version>
+    <version>4.31</version>
     <relativePath />
   </parent>
 
@@ -50,8 +50,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.249.x</artifactId>
-        <version>887.vae9c8ac09ff7</version>
+        <artifactId>bom-2.289.x</artifactId>
+        <version>1013.vf8058992a042</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/src/main/java/io/jenkins/plugins/dotnet/DotNetUtils.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/DotNetUtils.java
@@ -134,13 +134,17 @@ public interface DotNetUtils {
    * @return A suitably filled listbox model.
    */
   @NonNull
+  @SuppressWarnings("deprecation")
   static ListBoxModel getStringCredentialsList(@CheckForNull Jenkins context, boolean allowEmpty) {
     AbstractIdCredentialsListBoxModel<StandardListBoxModel, StandardCredentials> model = new StandardListBoxModel();
-    if (allowEmpty)
+    if (allowEmpty) {
       model = model.includeEmptyValue();
-    if (context == null || !context.hasPermission(CredentialsProvider.VIEW))
+    }
+    if (context == null || !context.hasPermission(CredentialsProvider.VIEW)) {
       return model;
-    model = model.includeMatchingAs(ACL.SYSTEM, context, StringCredentials.class, Collections.emptyList(), CredentialsMatchers.always());
+    }
+    // This should be ACL.SYSTEM2, but the Credential API has not yet been updated to use Spring Security.
+    model = model.includeAs(ACL.SYSTEM, context, StringCredentials.class);
     return model;
   }
 


### PR DESCRIPTION
This also bumps `plugin-parent` and `bom` to the latest versions.

The Credential API has not been updated to use Spring Security, so one
method was updated to ignore deprecation.
