### PR TITLE
Fix release drafter configuration

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,7 +2,8 @@ name: Release Drafter
 on:
   push:
     branches:
-      - master
+      - main
+  workflow_dispatch:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It was still using 'master' as the branch instead of 'main'.

This also adds a 'workflow_dispatch' trigger for manual launching.
