### PR TITLE
JENKINS-67450

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -6,12 +6,14 @@
       <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="20" />
       <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="10" />
       <option name="JD_ADD_BLANK_AFTER_PARM_COMMENTS" value="true" />
+      <option name="JD_ADD_BLANK_AFTER_RETURN" value="true" />
       <option name="JD_DO_NOT_WRAP_ONE_LINE_COMMENTS" value="true" />
     </JavaCodeStyleSettings>
     <codeStyleSettings language="JAVA">
       <option name="ELSE_ON_NEW_LINE" value="true" />
       <option name="CATCH_ON_NEW_LINE" value="true" />
       <option name="FINALLY_ON_NEW_LINE" value="true" />
+      <option name="WRAP_COMMENTS" value="true" />
     </codeStyleSettings>
   </code_scheme>
 </component>

--- a/src/main/java/io/jenkins/plugins/dotnet/DotNetSDK.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/DotNetSDK.java
@@ -76,7 +76,7 @@ public final class DotNetSDK extends ToolInstallation implements NodeSpecific<Do
   private boolean telemetryOptOut = true;
 
   /**
-   * Determines whether or not the telemetry opt-out is set.
+   * Determines whether the telemetry opt-out is set.
    *
    * @return {@code true} when the telemetry opt-out is set; {@code false} otherwise.
    */
@@ -85,7 +85,7 @@ public final class DotNetSDK extends ToolInstallation implements NodeSpecific<Do
   }
 
   /**
-   * Determines whether or not the telemetry opt-out should be set.
+   * Determines whether the telemetry opt-out should be set.
    *
    * @param telemetryOptOut {@code true} to opt out of telemetry; {@code false} otherwise.
    */
@@ -180,6 +180,7 @@ public final class DotNetSDK extends ToolInstallation implements NodeSpecific<Do
    * @param launcher The launcher to use for the verification.
    *
    * @return The full path to the {@code dotnet} executable in this .NET SDK installation.
+   *
    * @throws AbortException       When the executable could not be found.
    * @throws IOException          When an I/O error occurs.
    * @throws InterruptedException When processing is interrupted.
@@ -257,7 +258,7 @@ public final class DotNetSDK extends ToolInstallation implements NodeSpecific<Do
   }
 
   /**
-   * Determines whether or not any .NET SDKs have been configured.
+   * Determines whether any .NET SDKs have been configured.
    *
    * @return {@code true} when at least one .NET SDK has been configured; otherwise, {@code false}.
    */
@@ -355,6 +356,7 @@ public final class DotNetSDK extends ToolInstallation implements NodeSpecific<Do
      * @param listener  The task listener to use.
      *
      * @return The requested .NET SDK installation.
+     *
      * @throws AbortException       When the SDK installation could not be set up.
      * @throws IOException          Then an I/O error occurs.
      * @throws InterruptedException When processing is interrupted.

--- a/src/main/java/io/jenkins/plugins/dotnet/DotNetSDKInstaller.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/DotNetSDKInstaller.java
@@ -44,6 +44,7 @@ public final class DotNetSDKInstaller extends ToolInstaller {
    * @param log  The task listener to use for output.
    *
    * @return The SDK's installation location.
+   *
    * @throws IOException          When an I/O error occurs during processing.
    * @throws InterruptedException When processing is interrupted.
    */
@@ -72,7 +73,7 @@ public final class DotNetSDKInstaller extends ToolInstaller {
   private boolean includePreview;
 
   /**
-   * Determines whether or not .NET preview releases should be made available for installation.
+   * Determines whether .NET preview releases should be made available for installation.
    *
    * @return {@code true} if installation of .NET preview releases is allowed, {@code false} otherwise.
    */
@@ -81,7 +82,7 @@ public final class DotNetSDKInstaller extends ToolInstaller {
   }
 
   /**
-   * Determines whether or not .NET preview releases should be made available for installation.
+   * Determines whether .NET preview releases should be made available for installation.
    *
    * @param includePreview {@code true} to allow installation of .NET preview releases, {@code false} otherwise.
    */
@@ -327,7 +328,7 @@ public final class DotNetSDKInstaller extends ToolInstaller {
      * Fills a listbox with the names of .NET releases.
      *
      * @param version        The name of the .NET version containing the releases.
-     * @param includePreview Indicates whether or not preview releases should be included.
+     * @param includePreview Indicates whether preview releases should be included.
      *
      * @return A suitably filled listbox model.
      */
@@ -374,7 +375,7 @@ public final class DotNetSDKInstaller extends ToolInstaller {
     }
 
     /**
-     * Determines whether or not this installer is applicable for the specified type of tool.
+     * Determines whether this installer is applicable for the specified type of tool.
      *
      * @param toolType The type of tool to install.
      *

--- a/src/main/java/io/jenkins/plugins/dotnet/DotNetWrapper.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/DotNetWrapper.java
@@ -79,8 +79,8 @@ public class DotNetWrapper extends SimpleBuildWrapper {
    * most recent SDK version available on the system; with this set, a {@code global.json} file will be created to ensure a specific
    * SDK version gets used.
    *
-   * @param specificSdkVersion {@code true} if {@code global.json} should be used to ensure a specific SDK version gets used;
-   *                           {@code false} otherwise.
+   * @param specificSdkVersion {@code true} if {@code global.json} should be used to ensure a specific SDK version gets used; {@code
+   *                           false} otherwise.
    */
   @DataBoundSetter
   public void setSpecificSdkVersion(boolean specificSdkVersion) {
@@ -199,7 +199,7 @@ public class DotNetWrapper extends SimpleBuildWrapper {
     }
 
     /**
-     * Determines whether or not the .NET wrapper is applicable.
+     * Determines whether the .NET wrapper is applicable.
      *
      * @param item The project context.
      *

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/Command.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/Command.java
@@ -190,11 +190,11 @@ public class Command extends Builder implements SimpleBuildStep {
     this.sdk = Util.fixEmpty(sdk);
   }
 
-  /** Flag indicating whether or not SDK information should be shown. */
+  /** Flag indicating whether SDK information should be shown. */
   protected boolean showSdkInfo = false;
 
   /**
-   * Determines whether or not SDK information should be shown.
+   * Determines whether SDK information should be shown.
    *
    * @return {@code true} if "{@code dotnet --info}" should be run before the main command; {@code false} otherwise.
    */
@@ -204,7 +204,7 @@ public class Command extends Builder implements SimpleBuildStep {
   }
 
   /**
-   * Determines whether or not SDK information should be shown.
+   * Determines whether SDK information should be shown.
    *
    * @param showSdkInfo {@code true} if "{@code dotnet --info}" should be run before the main command; {@code false} otherwise.
    */
@@ -213,14 +213,14 @@ public class Command extends Builder implements SimpleBuildStep {
     this.showSdkInfo = showSdkInfo;
   }
 
-  /** Flag indicating whether or not any build servers started by the main command should be shut down. */
+  /** Flag indicating whether any build servers started by the main command should be shut down. */
   protected boolean shutDownBuildServers = false;
 
-  /** Flag indicating whether or not a specific SDK version should be used. */
+  /** Flag indicating whether a specific SDK version should be used. */
   private boolean specificSdkVersion = false;
 
   /**
-   * Determines whether or not a specific SDK version should be used.
+   * Determines whether a specific SDK version should be used.
    *
    * @return {@code true} if a {@code global.json} should be created to force the use of the configured .NET SDK (as opposed to a
    * more recent one that happens to be installed on the build agent); {@code false} otherwise.
@@ -231,7 +231,7 @@ public class Command extends Builder implements SimpleBuildStep {
   }
 
   /**
-   * Determines whether or not a specific SDK version should be used.
+   * Determines whether a specific SDK version should be used.
    *
    * @param specificSdkVersion {@code true} if a {@code global.json} should be created to force the use of the configured .NET SDK
    *                           (as opposed to a more recent one that happens to be installed on the build agent); {@code false}
@@ -243,7 +243,7 @@ public class Command extends Builder implements SimpleBuildStep {
     this.specificSdkVersion = specificSdkVersion;
   }
 
-  /** Flag indicating whether or not the presence of warnings makes the build unstable. */
+  /** Flag indicating whether the presence of warnings makes the build unstable. */
   protected boolean unstableIfWarnings = false;
 
   /** The working directory to use for the command. This directory is <em>not</em> created by the command execution. */

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/Command.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/Command.java
@@ -121,12 +121,17 @@ public class Command extends Builder implements SimpleBuildStep {
         launcher.launch().cmds(cmdLine).envs(env).stdout(scanner).pwd(workspace).join();
       }
       // TODO: Maybe also add configuration to set the build as either failed or unstable based on return code
-      if (rc != 0)
-        run.setResult(Result.FAILURE);
-      else if (scanner.getErrors() > 0)
-        run.setResult(Result.FAILURE);
-      else if (this.unstableIfWarnings && scanner.getWarnings() > 0)
-        run.setResult(Result.UNSTABLE);
+      if (scanner.getErrors() > 0) {
+        run.setResult(this.unstableIfErrors ? Result.UNSTABLE : Result.FAILURE);
+      }
+      else {
+        if (this.unstableIfWarnings && scanner.getWarnings() > 0) {
+          run.setResult(Result.UNSTABLE);
+        }
+        if (rc != 0) {
+          run.setResult(Result.FAILURE);
+        }
+      }
     }
     catch (Throwable t) {
       Functions.printStackTrace(t, listener.fatalError(Messages.Command_ExecutionFailed()));
@@ -243,7 +248,10 @@ public class Command extends Builder implements SimpleBuildStep {
     this.specificSdkVersion = specificSdkVersion;
   }
 
-  /** Flag indicating whether the presence of warnings makes the build unstable. */
+  /** Flag indicating whether the presence of errors makes the build unstable (instead of failed). */
+  protected boolean unstableIfErrors = false;
+
+  /** Flag indicating whether the presence of warnings makes the build unstable (instead of successful). */
   protected boolean unstableIfWarnings = false;
 
   /** The working directory to use for the command. This directory is <em>not</em> created by the command execution. */

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/Command.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/Command.java
@@ -172,6 +172,7 @@ public class Command extends Builder implements SimpleBuildStep {
    *
    * @return {@code true} if "{@code dotnet --info}" should be run before the main command; {@code false} otherwise.
    */
+  @SuppressWarnings("unused")
   public boolean isShowSdkInfo() {
     return this.showSdkInfo;
   }
@@ -198,6 +199,7 @@ public class Command extends Builder implements SimpleBuildStep {
    * @return {@code true} if a {@code global.json} should be created to force the use of the configured .NET SDK (as opposed to
    * a more recent one that happens to be installed on the build agent); {@code false} otherwise.
    */
+  @SuppressWarnings("unused")
   public boolean isSpecificSdkVersion() {
     return this.specificSdkVersion;
   }
@@ -210,6 +212,7 @@ public class Command extends Builder implements SimpleBuildStep {
    *                           otherwise.
    */
   @DataBoundSetter
+  @SuppressWarnings("unused")
   public void setSpecificSdkVersion(boolean specificSdkVersion) {
     this.specificSdkVersion = specificSdkVersion;
   }
@@ -227,6 +230,7 @@ public class Command extends Builder implements SimpleBuildStep {
    * @return The working directory to use for the command.
    */
   @CheckForNull
+  @SuppressWarnings("unused")
   public String getWorkDirectory() {
     return this.workDirectory;
   }
@@ -237,6 +241,7 @@ public class Command extends Builder implements SimpleBuildStep {
    * @param workDirectory The working directory to use for the command.
    */
   @DataBoundSetter
+  @SuppressWarnings("unused")
   public void setWorkDirectory(@CheckForNull String workDirectory) {
     this.workDirectory = Util.fixEmpty(workDirectory);
   }

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/Command.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/Command.java
@@ -73,7 +73,7 @@ public class Command extends Builder implements SimpleBuildStep {
    */
   @Override
   public void perform(@NonNull Run<?, ?> run, @NonNull FilePath workspace, @NonNull EnvVars env, @NonNull Launcher launcher, @NonNull TaskListener listener) throws InterruptedException, IOException {
-    final Charset cs = run.getCharset();
+    final Charset cs = this.charset == null ? run.getCharset() : Charset.forName(this.charset);
     final DotNetSDK sdkInstance;
     if (this.sdk == null)
       sdkInstance = null;
@@ -140,6 +140,32 @@ public class Command extends Builder implements SimpleBuildStep {
 
   //region Properties
 
+  /** A specific charset to use for the command's output. If {@code null}, the build's default charset will be used. */
+  @CheckForNull
+  private String charset = null;
+
+  /**
+   * Gets the specific charset to use for the command's output.
+   *
+   * @return The specific charset to use for the command's output, or {@code null} to indicate that the build's default charset
+   * should be used.
+   */
+  @CheckForNull
+  public String getCharset() {
+    return this.charset;
+  }
+
+  /**
+   * Sets the specific charset to use for the command's output.
+   *
+   * @param charset The specific charset to use for the command's output, or {@code null} to indicate that the build's default
+   *                charset should be used.
+   */
+  @DataBoundSetter
+  public void setCharset(@CheckForNull String charset) {
+    this.charset = Util.fixEmptyAndTrim(charset);
+  }
+
   /** The name of the SDK to use. */
   @CheckForNull
   protected String sdk;
@@ -196,8 +222,8 @@ public class Command extends Builder implements SimpleBuildStep {
   /**
    * Determines whether or not a specific SDK version should be used.
    *
-   * @return {@code true} if a {@code global.json} should be created to force the use of the configured .NET SDK (as opposed to
-   * a more recent one that happens to be installed on the build agent); {@code false} otherwise.
+   * @return {@code true} if a {@code global.json} should be created to force the use of the configured .NET SDK (as opposed to a
+   * more recent one that happens to be installed on the build agent); {@code false} otherwise.
    */
   @SuppressWarnings("unused")
   public boolean isSpecificSdkVersion() {

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/CommandDescriptor.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/CommandDescriptor.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.dotnet.commands;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Util;
 import hudson.model.AbstractProject;
 import hudson.model.AutoCompletionCandidates;
 import hudson.tasks.BuildStepDescriptor;
@@ -13,6 +14,9 @@ import io.jenkins.plugins.dotnet.data.Framework;
 import io.jenkins.plugins.dotnet.data.Runtime;
 import org.jenkinsci.plugins.structs.describable.CustomDescribableModel;
 import org.kohsuke.stapler.QueryParameter;
+
+import java.nio.charset.Charset;
+import java.util.Set;
 
 /** A descriptor for a .NET command. */
 public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> implements CustomDescribableModel {
@@ -88,6 +92,28 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
   }
 
   /**
+   * Performs validation on a Java charset name.
+   *
+   * @param value The value to validate.
+   *
+   * @return The result of the validation.
+   */
+  @SuppressWarnings("unused")
+  @NonNull
+  public FormValidation doCheckCharset(@CheckForNull @QueryParameter String value) {
+    final String name = Util.fixEmptyAndTrim(value);
+    if (name != null) {
+      try {
+        Charset.forName(value);
+      }
+      catch (Throwable t) {
+        return FormValidation.error(Messages.Command_UnsupportedCharset());
+      }
+    }
+    return FormValidation.ok();
+  }
+
+  /**
    * Performs validation on a .NET target framework moniker.
    *
    * @param value The value to validate.
@@ -137,6 +163,29 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
   @NonNull
   public FormValidation doCheckRuntimesString(@CheckForNull @QueryParameter String value) {
     return Runtime.getInstance().checkIdentifiers(value);
+  }
+
+  /**
+   * Fills a listbox with the names of charsets supported by the running version of Java.
+   *
+   * @return A suitably filled listbox model.
+   */
+  @SuppressWarnings("unused")
+  @NonNull
+  public final ListBoxModel doFillCharsetItems() {
+    final ListBoxModel model = new ListBoxModel();
+    model.add(Messages.Command_SameCharsetAsBuild(), "");
+    for (final Charset cs : Charset.availableCharsets().values()) {
+      final Set<String> aliases = cs.aliases();
+      final String name = cs.displayName();
+      if (aliases == null || aliases.isEmpty()) {
+        model.add(name);
+      }
+      else {
+        model.add(String.format("%s (%s)", name, String.join(" / ", aliases)), name);
+      }
+    }
+    return model;
   }
 
   /**

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/CommandDescriptor.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/CommandDescriptor.java
@@ -232,7 +232,7 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
   }
 
   /**
-   * Determines whether or not this descriptor is applicable for the specified job type.
+   * Determines whether this descriptor is applicable for the specified job type.
    *
    * @param jobType The job type.
    *

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/DotNetArguments.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/DotNetArguments.java
@@ -84,7 +84,7 @@ public final class DotNetArguments {
    * Adds a literal string argument, potentially masking it.
    *
    * @param value The literal string argument to add.
-   * @param mask  Indicates whether or not the argument should be masked.
+   * @param mask  Indicates whether the argument should be masked.
    *
    * @return This .NET CLI argument processor.
    */
@@ -124,8 +124,8 @@ public final class DotNetArguments {
   /**
    * Adds an option argument.
    *
-   * @param value The option argument to add; it will have variable substitution applied.
-   *              If it expands to {@code null}, no argument is added.
+   * @param value The option argument to add; it will have variable substitution applied. If it expands to {@code null}, no argument
+   *              is added.
    *
    * @return This .NET CLI argument processor.
    */
@@ -140,8 +140,8 @@ public final class DotNetArguments {
    * Adds an option argument.
    *
    * @param option The name of the option (without the {@code --} prefix).
-   * @param value  The option argument to add; it will be mapped to {@code "true"} or {@code "false"}.
-   *               If this is {@code null}, no argument is added.
+   * @param value  The option argument to add; it will be mapped to {@code "true"} or {@code "false"}. If this is {@code null}, no
+   *               argument is added.
    *
    * @return This .NET CLI argument processor.
    */
@@ -155,8 +155,8 @@ public final class DotNetArguments {
    * Adds an option argument.
    *
    * @param option The name of the option (without the {@code --} prefix).
-   * @param value  The option argument to add; it will be converted to its string representation is base 10.
-   *               If this is {@code null}, no argument is added.
+   * @param value  The option argument to add; it will be converted to its string representation is base 10. If this is {@code
+   *               null}, no argument is added.
    *
    * @return This .NET CLI argument processor.
    */
@@ -170,8 +170,8 @@ public final class DotNetArguments {
    * Adds an option argument.
    *
    * @param option The name of the option (without the {@code --} prefix).
-   * @param value  The option argument to add; it will have variable substitution applied.
-   *               If it expands to {@code null}, no argument is added.
+   * @param value  The option argument to add; it will have variable substitution applied. If it expands to {@code null}, no
+   *               argument is added.
    *
    * @return This .NET CLI argument processor.
    */
@@ -186,8 +186,8 @@ public final class DotNetArguments {
    * Adds an option argument.
    *
    * @param option The name of the option (without the {@code -} prefix or the {@code :} suffix).
-   * @param value  The option argument to add; it will have variable substitution applied.
-   *               If it expands to {@code null}, no argument is added.
+   * @param value  The option argument to add; it will have variable substitution applied. If it expands to {@code null}, no
+   *               argument is added.
    *
    * @return This .NET CLI argument processor.
    */
@@ -301,8 +301,8 @@ public final class DotNetArguments {
    * Adds an option argument containing a string credential.
    *
    * @param option The name of the option (without the {@code --} prefix).
-   * @param value  The string credential ID; it will have variable substitution applied.
-   *               If it expands to {@code null}, no argument is added.
+   * @param value  The string credential ID; it will have variable substitution applied. If it expands to {@code null}, no argument
+   *               is added.
    *
    * @return This .NET CLI argument processor.
    *
@@ -334,6 +334,7 @@ public final class DotNetArguments {
    * @param value The string credential ID; it will have variable substitution applied.
    *
    * @return The secret text for the given string credential.
+   *
    * @throws AbortException When the specified credential could not be found.
    */
   private Secret expandStringCredential(@CheckForNull String value) throws AbortException {

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/ListPackage.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/ListPackage.java
@@ -437,8 +437,8 @@ public final class ListPackage extends Command {
      * Performs validation on the "config file" setting.
      *
      * @param value      The specified configuration file name.
-     * @param deprecated Flag indicating whether or not deprecated packages should be listed.
-     * @param outdated   Flag indicating whether or not outdated packages should be listed.
+     * @param deprecated Flag indicating whether deprecated packages should be listed.
+     * @param outdated   Flag indicating whether outdated packages should be listed.
      *
      * @return The validation result.
      */
@@ -453,8 +453,8 @@ public final class ListPackage extends Command {
     /**
      * Performs validation on the "show deprecated packages" setting.
      *
-     * @param deprecated Flag indicating whether or not deprecated packages should be listed.
-     * @param outdated   Flag indicating whether or not outdated packages should be listed.
+     * @param deprecated Flag indicating whether deprecated packages should be listed.
+     * @param outdated   Flag indicating whether outdated packages should be listed.
      *
      * @return The validation result.
      */
@@ -469,9 +469,9 @@ public final class ListPackage extends Command {
     /**
      * Performs validation on the "highest minor" setting.
      *
-     * @param value      Flag indicating whether or not the minor version is the highest version that is allowed to change.
-     * @param deprecated Flag indicating whether or not deprecated packages should be listed.
-     * @param outdated   Flag indicating whether or not outdated packages should be listed.
+     * @param value      Flag indicating whether the minor version is the highest version that is allowed to change.
+     * @param deprecated Flag indicating whether deprecated packages should be listed.
+     * @param outdated   Flag indicating whether outdated packages should be listed.
      *
      * @return The validation result.
      */
@@ -486,9 +486,9 @@ public final class ListPackage extends Command {
     /**
      * Performs validation on the "highest patch" setting.
      *
-     * @param value      Flag indicating whether or not the patch version is the highest version that is allowed to change.
-     * @param deprecated Flag indicating whether or not deprecated packages should be listed.
-     * @param outdated   Flag indicating whether or not outdated packages should be listed.
+     * @param value      Flag indicating whether the patch version is the highest version that is allowed to change.
+     * @param deprecated Flag indicating whether deprecated packages should be listed.
+     * @param outdated   Flag indicating whether outdated packages should be listed.
      *
      * @return The validation result.
      */
@@ -503,9 +503,9 @@ public final class ListPackage extends Command {
     /**
      * Performs validation on the "include prerelease" setting.
      *
-     * @param value      Flag indicating whether or not prerelease package versions should be listed.
-     * @param deprecated Flag indicating whether or not deprecated packages should be listed.
-     * @param outdated   Flag indicating whether or not outdated packages should be listed.
+     * @param value      Flag indicating whether prerelease package versions should be listed.
+     * @param deprecated Flag indicating whether deprecated packages should be listed.
+     * @param outdated   Flag indicating whether outdated packages should be listed.
      *
      * @return The validation result.
      */
@@ -520,8 +520,8 @@ public final class ListPackage extends Command {
     /**
      * Performs validation on the "show outdated packages" setting.
      *
-     * @param deprecated Flag indicating whether or not deprecated packages should be listed.
-     * @param outdated   Flag indicating whether or not outdated packages should be listed.
+     * @param deprecated Flag indicating whether deprecated packages should be listed.
+     * @param outdated   Flag indicating whether outdated packages should be listed.
      *
      * @return The validation result.
      */
@@ -537,8 +537,8 @@ public final class ListPackage extends Command {
      * Performs validation on the "sources" setting.
      *
      * @param value      The specified package sources.
-     * @param deprecated Flag indicating whether or not deprecated packages should be listed.
-     * @param outdated   Flag indicating whether or not outdated packages should be listed.
+     * @param deprecated Flag indicating whether deprecated packages should be listed.
+     * @param outdated   Flag indicating whether outdated packages should be listed.
      *
      * @return The validation result.
      */

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/Restore.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/Restore.java
@@ -96,7 +96,7 @@ public final class Restore extends Command {
   private boolean disableParallel;
 
   /**
-   * Determines whether or not multiple projects can be restored in parallel.
+   * Determines whether multiple projects can be restored in parallel.
    *
    * @return {@code true} when multiple projects are restored one by one; {@code false} otherwise.
    */
@@ -105,7 +105,7 @@ public final class Restore extends Command {
   }
 
   /**
-   * Determines whether or not multiple projects can be restored in parallel.
+   * Determines whether multiple projects can be restored in parallel.
    *
    * @param disableParallel {@code true} to restore multiple projects one by one; {@code false} otherwise.
    */
@@ -117,7 +117,7 @@ public final class Restore extends Command {
   private boolean force;
 
   /**
-   * Determines whether or not dependency resolution should be forced.
+   * Determines whether dependency resolution should be forced.
    *
    * @return {@code true} when all dependencies should be resolved even if the last restore was successful; {@code false} otherwise.
    */
@@ -126,7 +126,7 @@ public final class Restore extends Command {
   }
 
   /**
-   * Determines whether or not dependency resolution should be forced.
+   * Determines whether dependency resolution should be forced.
    *
    * @param force {@code true} to resolve all dependencies even if the last restore was successful; {@code false} otherwise.
    */
@@ -138,7 +138,7 @@ public final class Restore extends Command {
   private boolean forceEvaluate;
 
   /**
-   * Determines whether or not all dependencies should be re-evaluated even when a lock file exists.
+   * Determines whether all dependencies should be re-evaluated even when a lock file exists.
    *
    * @return {@code true} when all dependencies are re-evaluated even when a lock file exists; {@code false} otherwise.
    */
@@ -147,7 +147,7 @@ public final class Restore extends Command {
   }
 
   /**
-   * Determines whether or not all dependencies should be re-evaluated even when a lock file exists.
+   * Determines whether all dependencies should be re-evaluated even when a lock file exists.
    *
    * @param forceEvaluate {@code true} to re-evaluate all dependencies even when a lock file exists; {@code false} otherwise.
    */
@@ -159,7 +159,7 @@ public final class Restore extends Command {
   private boolean ignoreFailedSources;
 
   /**
-   * Determines whether or not failed sources should be ignored.
+   * Determines whether failed sources should be ignored.
    *
    * @return {@code true} when failed sources are ignored; {@code false} otherwise.
    */
@@ -168,7 +168,7 @@ public final class Restore extends Command {
   }
 
   /**
-   * Determines whether or not failed sources should be ignored.
+   * Determines whether failed sources should be ignored.
    *
    * @param ignoreFailedSources {@code true} to ignore failed sources; {@code false} otherwise.
    */
@@ -202,7 +202,7 @@ public final class Restore extends Command {
   private boolean lockedMode;
 
   /**
-   * Determines whether or not updating the project lock file is allowed.
+   * Determines whether updating the project lock file is allowed.
    *
    * @return {@code true} when updating the project lock file is not allowed; {@code false} otherwise.
    */
@@ -211,7 +211,7 @@ public final class Restore extends Command {
   }
 
   /**
-   * Determines whether or not updating the project lock file is allowed.
+   * Determines whether updating the project lock file is allowed.
    *
    * @param lockedMode {@code true} to disallow updating the project lock file; {@code false} otherwise.
    */
@@ -223,7 +223,7 @@ public final class Restore extends Command {
   private boolean noCache;
 
   /**
-   * Determines whether or not HTTP requests should be cached.
+   * Determines whether HTTP requests should be cached.
    *
    * @return {@code true} when HTTP requests are not cached; {@code false} otherwise.
    */
@@ -232,7 +232,7 @@ public final class Restore extends Command {
   }
 
   /**
-   * Determines whether or not HTTP requests should be cached.
+   * Determines whether HTTP requests should be cached.
    *
    * @param noCache {@code true} not to cache HTTP requests; {@code false} otherwise.
    */
@@ -244,7 +244,7 @@ public final class Restore extends Command {
   private boolean noDependencies;
 
   /**
-   * Determines whether or not to ignore project-to-project dependencies.
+   * Determines whether to ignore project-to-project dependencies.
    *
    * @return {@code true} when project-to-project dependencies are ignored; {@code false} otherwise.
    */
@@ -253,7 +253,7 @@ public final class Restore extends Command {
   }
 
   /**
-   * Determines whether or not to ignore project-to-project dependencies.
+   * Determines whether to ignore project-to-project dependencies.
    *
    * @param noDependencies {@code true} when project-to-project dependencies should be ignored; {@code false} otherwise.
    */
@@ -437,7 +437,7 @@ public final class Restore extends Command {
   private boolean useLockFile;
 
   /**
-   * Determines whether or not a project lock file should be generated and used.
+   * Determines whether a project lock file should be generated and used.
    *
    * @return {@code true} when a project lock file is generated and used; {@code false} otherwise.
    */
@@ -446,7 +446,7 @@ public final class Restore extends Command {
   }
 
   /**
-   * Determines whether or not a project lock file should be generated and used.
+   * Determines whether a project lock file should be generated and used.
    *
    * @param useLockFile {@code true} to generate and use a project lock file; {@code false} otherwise.
    */

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Build.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Build.java
@@ -63,7 +63,7 @@ public final class Build extends MSBuildCommand {
   private boolean force;
 
   /**
-   * Determines whether or not dependency resolution should be forced.
+   * Determines whether dependency resolution should be forced.
    *
    * @return {@code true} when all dependencies should be resolved even if the last restore was successful; {@code false} otherwise.
    */
@@ -72,7 +72,7 @@ public final class Build extends MSBuildCommand {
   }
 
   /**
-   * Determines whether or not dependency resolution should be forced.
+   * Determines whether dependency resolution should be forced.
    *
    * @param force {@code true} to resolve all dependencies even if the last restore was successful; {@code false} otherwise.
    */
@@ -106,7 +106,7 @@ public final class Build extends MSBuildCommand {
   private boolean noDependencies;
 
   /**
-   * Determines whether or not to ignore project-to-project dependencies.
+   * Determines whether to ignore project-to-project dependencies.
    *
    * @return {@code true} when project-to-project dependencies are ignored; {@code false} otherwise.
    */
@@ -115,7 +115,7 @@ public final class Build extends MSBuildCommand {
   }
 
   /**
-   * Determines whether or not to ignore project-to-project dependencies.
+   * Determines whether to ignore project-to-project dependencies.
    *
    * @param noDependencies {@code true} when project-to-project dependencies should be ignored; {@code false} otherwise.
    */
@@ -127,7 +127,7 @@ public final class Build extends MSBuildCommand {
   private boolean noIncremental;
 
   /**
-   * Determines whether or not incremental builds are allowed.
+   * Determines whether incremental builds are allowed.
    *
    * @return {@code true} when incremental builds are disabled; {@code false} otherwise.
    */
@@ -136,7 +136,7 @@ public final class Build extends MSBuildCommand {
   }
 
   /**
-   * Determines whether or not incremental builds are allowed.
+   * Determines whether incremental builds are allowed.
    *
    * @param noIncremental {@code true} to disallow incremental builds; {@code false} otherwise.
    */
@@ -148,7 +148,7 @@ public final class Build extends MSBuildCommand {
   private boolean noRestore;
 
   /**
-   * Determines whether or not an implicit restore should be executed as part of this command.
+   * Determines whether an implicit restore should be executed as part of this command.
    *
    * @return {@code true} when the implicit restore is disabled; {@code false} otherwise.
    */
@@ -157,7 +157,7 @@ public final class Build extends MSBuildCommand {
   }
 
   /**
-   * Determines whether or not an implicit restore should be executed as part of this command.
+   * Determines whether an implicit restore should be executed as part of this command.
    *
    * @param noRestore {@code true} to disable the implicit restore; {@code false} otherwise.
    */

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/MSBuildCommand.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/MSBuildCommand.java
@@ -94,11 +94,11 @@ public class MSBuildCommand extends Command {
     this.configuration = Util.fixEmptyAndTrim(configuration);
   }
 
-  /** Flag indicating whether or not the MSBuild version/copyright lines should be suppressed. */
+  /** Flag indicating whether the MSBuild version/copyright lines should be suppressed. */
   protected boolean nologo;
 
   /**
-   * Determines whether or not the MSBuild version/copyright lines should be suppressed.
+   * Determines whether the MSBuild version/copyright lines should be suppressed.
    *
    * @return {@code true} if the MSBuild startup banner should be suppressed; {@code false} otherwise.
    */
@@ -107,7 +107,7 @@ public class MSBuildCommand extends Command {
   }
 
   /**
-   * Determines whether or not the MSBuild version/copyright lines should be suppressed.
+   * Determines whether the MSBuild version/copyright lines should be suppressed.
    *
    * @param noLogo {@code true} if the MSBuild startup banner should be suppressed; {@code false} otherwise.
    */
@@ -117,8 +117,8 @@ public class MSBuildCommand extends Command {
   }
 
   /**
-   * Additional options to pass to the command.
-   * Options specified via more specific settings will take precedence over options specified here.
+   * Additional options to pass to the command. Options specified via more specific settings will take precedence over options
+   * specified here.
    */
   @CheckForNull
   protected String options;
@@ -156,8 +156,8 @@ public class MSBuildCommand extends Command {
   }
 
   /**
-   * Sets additional options to pass to the command.
-   * Options specified via more specific settings will take precedence over options specified here.
+   * Sets additional options to pass to the command. Options specified via more specific settings will take precedence over options
+   * specified here.
    *
    * @param options Additional options to pass to the command.
    */
@@ -167,8 +167,8 @@ public class MSBuildCommand extends Command {
   }
 
   /**
-   * Gets additional options to pass to the command.
-   * Options specified via more specific settings will take precedence over options specified here.
+   * Gets additional options to pass to the command. Options specified via more specific settings will take precedence over options
+   * specified here.
    *
    * @return Additional options to pass to the command.
    */
@@ -178,8 +178,8 @@ public class MSBuildCommand extends Command {
   }
 
   /**
-   * Sets additional options to pass to the command.
-   * Options specified via more specific settings will take precedence over options specified here.
+   * Sets additional options to pass to the command. Options specified via more specific settings will take precedence over options
+   * specified here.
    *
    * @param options Additional options to pass to the command.
    */
@@ -217,9 +217,8 @@ public class MSBuildCommand extends Command {
   protected String project;
 
   /**
-   * Gets the name of the project file to process.
-   * For some commands, this can also be a directory or a solution file.
-   * When {@code null}, a project or solution from the current directory will usually be processed.
+   * Gets the name of the project file to process. For some commands, this can also be a directory or a solution file. When {@code
+   * null}, a project or solution from the current directory will usually be processed.
    *
    * @return The project to process.
    */
@@ -229,9 +228,8 @@ public class MSBuildCommand extends Command {
   }
 
   /**
-   * Sets the name of the project file to process.
-   * For some commands, this can also be a directory or a solution file.
-   * When {@code null}, a project or solution from the current directory will usually be processed.
+   * Sets the name of the project file to process. For some commands, this can also be a directory or a solution file. When {@code
+   * null}, a project or solution from the current directory will usually be processed.
    *
    * @param project The project to process.
    */
@@ -289,7 +287,7 @@ public class MSBuildCommand extends Command {
   }
 
   /**
-   * Determines whether or not any build servers started by the main command should be shut down.
+   * Determines whether any build servers started by the main command should be shut down.
    *
    * @return {@code true} if "{@code dotnet build-server shutdown}" should be run after the main command; {@code false} otherwise.
    */
@@ -298,10 +296,10 @@ public class MSBuildCommand extends Command {
   }
 
   /**
-   * Determines whether or not any build servers started by the main command should be shut down.
+   * Determines whether any build servers started by the main command should be shut down.
    *
-   * @param shutDownBuildServers {@code true} if "{@code dotnet build-server shutdown}" should be run after the main command;
-   *                             {@code false} otherwise.
+   * @param shutDownBuildServers {@code true} if "{@code dotnet build-server shutdown}" should be run after the main command; {@code
+   *                             false} otherwise.
    */
   @DataBoundSetter
   public void setShutDownBuildServers(boolean shutDownBuildServers) {
@@ -309,7 +307,7 @@ public class MSBuildCommand extends Command {
   }
 
   /**
-   * Determines whether or not the presence of warnings makes the build unstable.
+   * Determines whether the presence of warnings makes the build unstable.
    *
    * @return {@code true} if warnings cause the build to be marked as unstable; {@code false} otherwise.
    */
@@ -318,7 +316,7 @@ public class MSBuildCommand extends Command {
   }
 
   /**
-   * Determines whether or not the presence of warnings makes the build unstable.
+   * Determines whether the presence of warnings makes the build unstable.
    *
    * @param unstableIfWarnings {@code true} if warnings cause the build to be marked as unstable; {@code false} otherwise.
    */

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/MSBuildCommand.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/MSBuildCommand.java
@@ -307,18 +307,39 @@ public class MSBuildCommand extends Command {
   }
 
   /**
-   * Determines whether the presence of warnings makes the build unstable.
+   * Determines whether the presence of errors makes the build unstable (instead of failed).
    *
-   * @return {@code true} if warnings cause the build to be marked as unstable; {@code false} otherwise.
+   * @return {@code true} if errors cause the build to be marked as unstable (instead of failed); {@code false} otherwise.
+   */
+  public boolean isUnstableIfErrors() {
+    return this.unstableIfErrors;
+  }
+
+  /**
+   * Determines whether the presence of errors makes the build unstable (instead of failed).
+   *
+   * @param unstableIfErrors {@code true} if errors cause the build to be marked as unstable (instead of failed); {@code false}
+   *                         otherwise.
+   */
+  @DataBoundSetter
+  public void setUnstableIfErrors(boolean unstableIfErrors) {
+    this.unstableIfErrors = unstableIfErrors;
+  }
+
+  /**
+   * Determines whether the presence of warnings makes the build unstable (instead of successful).
+   *
+   * @return {@code true} if warnings cause the build to be marked as unstable (instead of successful); {@code false} otherwise.
    */
   public boolean isUnstableIfWarnings() {
     return this.unstableIfWarnings;
   }
 
   /**
-   * Determines whether the presence of warnings makes the build unstable.
+   * Determines whether the presence of warnings makes the build unstable (instead of successful).
    *
-   * @param unstableIfWarnings {@code true} if warnings cause the build to be marked as unstable; {@code false} otherwise.
+   * @param unstableIfWarnings {@code true} if warnings cause the build to be marked as unstable (instead of successful); {@code
+   *                           false} otherwise.
    */
   @DataBoundSetter
   public void setUnstableIfWarnings(boolean unstableIfWarnings) {

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Pack.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Pack.java
@@ -53,7 +53,7 @@ public final class Pack extends MSBuildCommand {
   private boolean force;
 
   /**
-   * Determines whether or not dependency resolution should be forced.
+   * Determines whether dependency resolution should be forced.
    *
    * @return {@code true} when all dependencies should be resolved even if the last restore was successful; {@code false} otherwise.
    */
@@ -62,7 +62,7 @@ public final class Pack extends MSBuildCommand {
   }
 
   /**
-   * Determines whether or not dependency resolution should be forced.
+   * Determines whether dependency resolution should be forced.
    *
    * @param force {@code true} to resolve all dependencies even if the last restore was successful; {@code false} otherwise.
    */
@@ -74,7 +74,7 @@ public final class Pack extends MSBuildCommand {
   private boolean includeSource;
 
   /**
-   * Determines whether or not symbol packages containing source code should be created.
+   * Determines whether symbol packages containing source code should be created.
    *
    * @return {@code true} when symbol packages are created containing source code; {@code false} otherwise.
    */
@@ -83,7 +83,7 @@ public final class Pack extends MSBuildCommand {
   }
 
   /**
-   * Determines whether or not symbol packages containing source code should be created.
+   * Determines whether symbol packages containing source code should be created.
    *
    * @param includeSource {@code true} to create symbol packages containing source code; {@code false} otherwise.
    */
@@ -95,7 +95,7 @@ public final class Pack extends MSBuildCommand {
   private boolean includeSymbols;
 
   /**
-   * Determines whether or not symbol packages should be created.
+   * Determines whether symbol packages should be created.
    *
    * @return {@code true} when symbol packages are created; {@code false} otherwise.
    */
@@ -104,7 +104,7 @@ public final class Pack extends MSBuildCommand {
   }
 
   /**
-   * Determines whether or not symbol packages should be created.
+   * Determines whether symbol packages should be created.
    *
    * @param includeSymbols {@code true} to create symbol packages; {@code false} otherwise.
    */
@@ -116,7 +116,7 @@ public final class Pack extends MSBuildCommand {
   private boolean noBuild;
 
   /**
-   * Determines whether or not a build should be performed before creating the packages.
+   * Determines whether a build should be performed before creating the packages.
    *
    * @return {@code true} when neither a restore nor a build will be performed before creating the packages; {@code false}
    * otherwise.
@@ -126,7 +126,7 @@ public final class Pack extends MSBuildCommand {
   }
 
   /**
-   * Determines whether or not a build should be performed before creating the packages.
+   * Determines whether a build should be performed before creating the packages.
    *
    * @param noBuild {@code true} to perform neither a restore nor a build before creating the packages; {@code false} otherwise.
    */
@@ -138,7 +138,7 @@ public final class Pack extends MSBuildCommand {
   private boolean noDependencies;
 
   /**
-   * Determines whether or not to ignore project-to-project dependencies.
+   * Determines whether to ignore project-to-project dependencies.
    *
    * @return {@code true} when project-to-project dependencies are ignored; {@code false} otherwise.
    */
@@ -147,7 +147,7 @@ public final class Pack extends MSBuildCommand {
   }
 
   /**
-   * Determines whether or not to ignore project-to-project dependencies.
+   * Determines whether to ignore project-to-project dependencies.
    *
    * @param noDependencies {@code true} when project-to-project dependencies should be ignored; {@code false} otherwise.
    */
@@ -159,7 +159,7 @@ public final class Pack extends MSBuildCommand {
   private boolean noRestore;
 
   /**
-   * Determines whether or not an implicit restore should be executed as part of this command.
+   * Determines whether an implicit restore should be executed as part of this command.
    *
    * @return {@code true} when the implicit restore is disabled; {@code false} otherwise.
    */
@@ -168,7 +168,7 @@ public final class Pack extends MSBuildCommand {
   }
 
   /**
-   * Determines whether or not an implicit restore should be executed as part of this command.
+   * Determines whether an implicit restore should be executed as part of this command.
    *
    * @param noRestore {@code true} to disable the implicit restore; {@code false} otherwise.
    */

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Publish.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Publish.java
@@ -64,7 +64,7 @@ public final class Publish extends MSBuildCommand {
   private boolean force;
 
   /**
-   * Determines whether or not dependency resolution should be forced.
+   * Determines whether dependency resolution should be forced.
    *
    * @return {@code true} when all dependencies should be resolved even if the last restore was successful; {@code false} otherwise.
    */
@@ -73,7 +73,7 @@ public final class Publish extends MSBuildCommand {
   }
 
   /**
-   * Determines whether or not dependency resolution should be forced.
+   * Determines whether dependency resolution should be forced.
    *
    * @param force {@code true} to resolve all dependencies even if the last restore was successful; {@code false} otherwise.
    */
@@ -171,7 +171,7 @@ public final class Publish extends MSBuildCommand {
   private boolean noBuild;
 
   /**
-   * Determines whether or not a build should be performed before publishing.
+   * Determines whether a build should be performed before publishing.
    *
    * @return {@code true} when neither a restore nor a build will be performed before publishing; {@code false} otherwise.
    */
@@ -180,7 +180,7 @@ public final class Publish extends MSBuildCommand {
   }
 
   /**
-   * Determines whether or not a build should be performed before publishing.
+   * Determines whether a build should be performed before publishing.
    *
    * @param noBuild {@code true} to perform neither a restore nor a build before publishing; {@code false} otherwise.
    */
@@ -192,7 +192,7 @@ public final class Publish extends MSBuildCommand {
   private boolean noDependencies;
 
   /**
-   * Determines whether or not to ignore project-to-project dependencies.
+   * Determines whether to ignore project-to-project dependencies.
    *
    * @return {@code true} when project-to-project dependencies are ignored; {@code false} otherwise.
    */
@@ -201,7 +201,7 @@ public final class Publish extends MSBuildCommand {
   }
 
   /**
-   * Determines whether or not to ignore project-to-project dependencies.
+   * Determines whether to ignore project-to-project dependencies.
    *
    * @param noDependencies {@code true} when project-to-project dependencies should be ignored; {@code false} otherwise.
    */
@@ -213,7 +213,7 @@ public final class Publish extends MSBuildCommand {
   private boolean noRestore;
 
   /**
-   * Determines whether or not an implicit restore should be executed as part of this command.
+   * Determines whether an implicit restore should be executed as part of this command.
    *
    * @return {@code true} when the implicit restore is disabled; {@code false} otherwise.
    */
@@ -222,7 +222,7 @@ public final class Publish extends MSBuildCommand {
   }
 
   /**
-   * Determines whether or not an implicit restore should be executed as part of this command.
+   * Determines whether an implicit restore should be executed as part of this command.
    *
    * @param noRestore {@code true} to disable the implicit restore; {@code false} otherwise.
    */
@@ -256,7 +256,7 @@ public final class Publish extends MSBuildCommand {
   private Boolean selfContained;
 
   /**
-   * Determines whether or not the project should be published self-contained.
+   * Determines whether the project should be published self-contained.
    *
    * @return {@code null} when the project decides; {@code true} when publishing self-contained; {@code false} otherwise.
    */
@@ -266,7 +266,7 @@ public final class Publish extends MSBuildCommand {
   }
 
   /**
-   * Determines whether or not the project should be published self-contained.
+   * Determines whether the project should be published self-contained.
    *
    * @param selfContained {@code null} to let the project decide; {@code true} to publish self-contained; {@code false} otherwise.
    */

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Test.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Test.java
@@ -103,7 +103,7 @@ public final class Test extends MSBuildCommand {
   private boolean blame;
 
   /**
-   * Determines whether or not tests should be run in blame mode, to diagnose test host crashes.
+   * Determines whether tests should be run in blame mode, to diagnose test host crashes.
    *
    * @return {@code true} when tests are run in blame mode; {@code false} otherwise.
    */
@@ -112,7 +112,7 @@ public final class Test extends MSBuildCommand {
   }
 
   /**
-   * Determines whether or not tests should be run in blame mode, to diagnose test host crashes.
+   * Determines whether tests should be run in blame mode, to diagnose test host crashes.
    *
    * @param blame {@code true} to run tests in blame mode; {@code false} otherwise.
    */
@@ -124,7 +124,7 @@ public final class Test extends MSBuildCommand {
   private boolean blameCrash;
 
   /**
-   * Determines whether or not crash dumps should be collected in blame mode.
+   * Determines whether crash dumps should be collected in blame mode.
    *
    * @return {@code true} when crash dumps are collected; {@code false} otherwise.
    */
@@ -133,7 +133,7 @@ public final class Test extends MSBuildCommand {
   }
 
   /**
-   * Determines whether or not crash dumps should be collected in blame mode.
+   * Determines whether crash dumps should be collected in blame mode.
    *
    * @param blameCrash {@code true} to collect crash dumps; {@code false} otherwise.
    */
@@ -145,7 +145,7 @@ public final class Test extends MSBuildCommand {
   private boolean blameCrashCollectAlways;
 
   /**
-   * Determines whether or not crash dumps should be collected in blame mode even for expected test host termination.
+   * Determines whether crash dumps should be collected in blame mode even for expected test host termination.
    *
    * @return {@code true} when crash dumps are collected even for expected test host termination; {@code false} otherwise.
    */
@@ -154,7 +154,7 @@ public final class Test extends MSBuildCommand {
   }
 
   /**
-   * Determines whether or not crash dumps should be collected in blame mode even for expected test host termination.
+   * Determines whether crash dumps should be collected in blame mode even for expected test host termination.
    *
    * @param blameCrashCollectAlways {@code true} to collect crash dumps even for expected test host termination; {@code false}
    *                                otherwise.
@@ -189,7 +189,7 @@ public final class Test extends MSBuildCommand {
   private boolean blameHang;
 
   /**
-   * Determines whether or not test timeouts should result in termination.
+   * Determines whether test timeouts should result in termination.
    *
    * @return {@code true} when test timeouts result in termination; {@code false} otherwise.
    */
@@ -198,7 +198,7 @@ public final class Test extends MSBuildCommand {
   }
 
   /**
-   * Determines whether or not test timeouts should result in termination.
+   * Determines whether test timeouts should result in termination.
    *
    * @param blameHang {@code true} to terminate execution when a test times out; {@code false} otherwise.
    */
@@ -342,7 +342,7 @@ public final class Test extends MSBuildCommand {
   private boolean listTests;
 
   /**
-   * Determines whether or not discovered tests should be listed.
+   * Determines whether discovered tests should be listed.
    *
    * @return {@code true} when discovered tests are listed; {@code false} otherwise.
    */
@@ -351,7 +351,7 @@ public final class Test extends MSBuildCommand {
   }
 
   /**
-   * Determines whether or not discovered tests should be listed.
+   * Determines whether discovered tests should be listed.
    *
    * @param listTests {@code true} to list discovered tests; {@code false} otherwise.
    */
@@ -385,7 +385,7 @@ public final class Test extends MSBuildCommand {
   private boolean noBuild;
 
   /**
-   * Determines whether or not a build should be performed before running tests.
+   * Determines whether a build should be performed before running tests.
    *
    * @return {@code true} when neither a restore nor a build will be performed before running tests; {@code false} otherwise.
    */
@@ -394,7 +394,7 @@ public final class Test extends MSBuildCommand {
   }
 
   /**
-   * Determines whether or not a build should be performed before running tests.
+   * Determines whether a build should be performed before running tests.
    *
    * @param noBuild {@code true} to perform neither a restore nor a build before running tests; {@code false} otherwise.
    */
@@ -406,7 +406,7 @@ public final class Test extends MSBuildCommand {
   private boolean noRestore;
 
   /**
-   * Determines whether or not an implicit restore should be executed as part of this command.
+   * Determines whether an implicit restore should be executed as part of this command.
    *
    * @return {@code true} when the implicit restore is disabled; {@code false} otherwise.
    */
@@ -415,7 +415,7 @@ public final class Test extends MSBuildCommand {
   }
 
   /**
-   * Determines whether or not an implicit restore should be executed as part of this command.
+   * Determines whether an implicit restore should be executed as part of this command.
    *
    * @param noRestore {@code true} to disable the implicit restore; {@code false} otherwise.
    */

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/tool/Restore.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/tool/Restore.java
@@ -142,7 +142,7 @@ public final class Restore extends ToolCommand {
   private boolean disableParallel;
 
   /**
-   * Determines whether or not multiple projects can be restored in parallel.
+   * Determines whether multiple projects can be restored in parallel.
    *
    * @return {@code true} when multiple projects are restored one by one; {@code false} otherwise.
    */
@@ -151,7 +151,7 @@ public final class Restore extends ToolCommand {
   }
 
   /**
-   * Determines whether or not multiple projects can be restored in parallel.
+   * Determines whether multiple projects can be restored in parallel.
    *
    * @param disableParallel {@code true} to restore multiple projects one by one; {@code false} otherwise.
    */
@@ -163,7 +163,7 @@ public final class Restore extends ToolCommand {
   private boolean ignoreFailedSources;
 
   /**
-   * Determines whether or not failed sources should be ignored.
+   * Determines whether failed sources should be ignored.
    *
    * @return {@code true} when failed sources are ignored; {@code false} otherwise.
    */
@@ -172,7 +172,7 @@ public final class Restore extends ToolCommand {
   }
 
   /**
-   * Determines whether or not failed sources should be ignored.
+   * Determines whether failed sources should be ignored.
    *
    * @param ignoreFailedSources {@code true} to ignore failed sources; {@code false} otherwise.
    */
@@ -184,7 +184,7 @@ public final class Restore extends ToolCommand {
   private boolean noCache;
 
   /**
-   * Determines whether or not HTTP requests should be cached.
+   * Determines whether HTTP requests should be cached.
    *
    * @return {@code true} when HTTP requests are not cached; {@code false} otherwise.
    */
@@ -193,7 +193,7 @@ public final class Restore extends ToolCommand {
   }
 
   /**
-   * Determines whether or not HTTP requests should be cached.
+   * Determines whether HTTP requests should be cached.
    *
    * @param noCache {@code true} not to cache HTTP requests; {@code false} otherwise.
    */

--- a/src/main/java/io/jenkins/plugins/dotnet/data/Downloads.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/data/Downloads.java
@@ -134,7 +134,7 @@ public final class Downloads extends DownloadService.Downloadable {
    *
    * @param model          The list box to add the releases to.
    * @param version        The name of the version containing the releases to add.
-   * @param includePreview Indicates whether or not preview releases should be included.
+   * @param includePreview Indicates whether preview releases should be included.
    *
    * @return The updated list box.
    */
@@ -399,10 +399,10 @@ public final class Downloads extends DownloadService.Downloadable {
     @NonNull
     public String released;
 
-    /** Indicates whether or not this release is a preview. */
+    /** Indicates whether this release is a preview. */
     public boolean preview;
 
-    /** Indicates whether or not this release contains security fixes. */
+    /** Indicates whether this release contains security fixes. */
     public boolean securityFixes;
 
     /** A link to the release notes for this release. */

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/Command/help-charset.html
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/Command/help-charset.html
@@ -1,0 +1,3 @@
+<div>
+  The character set to use for the step's output. If not specified, the charset associated with the build will be used.
+</div>

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/Command/moreOptions.jelly
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/Command/moreOptions.jelly
@@ -1,6 +1,10 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
 
+  <f:entry title="${%Output Character Set}" field="charset">
+    <f:select/>
+  </f:entry>
+
   <f:entry title="${%Show SDK Information}" field="showSdkInfo">
     <f:checkbox/>
   </f:entry>

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/Command/moreOptions_fr.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/Command/moreOptions_fr.properties
@@ -1,1 +1,3 @@
+Output\ Character\ Set=Jeu de caractères de la sortie
+Require\ Specific\ SDK\ Version=Exiger une version spécifique du SDK
 Show\ SDK\ Information=Afficher les informations du SDK

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/Command/moreOptions_nl.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/Command/moreOptions_nl.properties
@@ -1,1 +1,3 @@
+Output\ Character\ Set=Tekenset van de uitvoer
+Require\ Specific\ SDK\ Version=Specifieke SDK-versie vereisen
 Show\ SDK\ Information=SDK-informatie weergeven

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/Messages.properties
@@ -1,6 +1,8 @@
 Command.DefaultSDK=(Default)
 Command.ExecutionFailed=Command execution failed
 Command.MoreOptions=More Options
+Command.SameCharsetAsBuild=<Same As Rest of Build>
+Command.UnsupportedCharset=Unsupported character set
 Command.Verbosity.Default=(Default)
 Command.Verbosity.Quiet=Quiet (q)
 Command.Verbosity.Minimal=Minimal (m)

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/Messages_fr.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/Messages_fr.properties
@@ -1,6 +1,8 @@
 Command.DefaultSDK=(Défaut)
-Command.ExecutionFailed=L'exécution de la commande a échoué
+Command.ExecutionFailed=L'exécution de l'ordre a échoué
 Command.MoreOptions=Options additionelles
+Command.SameCharsetAsBuild=Identique au reste du build
+Command.UnsupportedCharset=Jeu de caractères non supporté
 Command.Verbosity.Default=(Défaut)
 Command.Verbosity.Quiet=Silencieux (q)
 Command.Verbosity.Minimal=Minimale (m)

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/Messages_nl.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/Messages_nl.properties
@@ -1,6 +1,8 @@
 Command.DefaultSDK=(Standaard)
 Command.ExecutionFailed=Uitvoeren van commando mislukt
 Command.MoreOptions=Meer opties
+Command.SameCharsetAsBuild=<Hetzelfde als de rest van de build>
+Command.UnsupportedCharset=Deze tekenset wordt niet ondersteund
 Command.Verbosity.Default=(Standaard)
 Command.Verbosity.Quiet=Stil (q)
 Command.Verbosity.Minimal=Minimaal (m)

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/msbuild/MSBuildCommand/help-unstableIfErrors.html
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/msbuild/MSBuildCommand/help-unstableIfErrors.html
@@ -1,0 +1,3 @@
+<div>
+  If this is set and the build completes with errors, the build will be marked as unstable instead of failed.
+</div>

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/msbuild/MSBuildCommand/help-unstableIfWarnings.html
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/msbuild/MSBuildCommand/help-unstableIfWarnings.html
@@ -1,3 +1,3 @@
 <div>
-  If this is set and the build completes successfully with warnings, the build will be marked as unstable.
+  If this is set and the build completes with warnings (but no errors), the build will be marked as unstable instead of successful.
 </div>

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/msbuild/MSBuildCommand/options.jelly
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/msbuild/MSBuildCommand/options.jelly
@@ -7,6 +7,10 @@
     <f:combobox/>
   </f:entry>
 
+  <f:entry title="${%Errors Result in Unstable Build}" field="unstableIfErrors">
+    <f:checkbox/>
+  </f:entry>
+
   <f:entry title="${%Warnings Result in Unstable Build}" field="unstableIfWarnings">
     <f:checkbox/>
   </f:entry>

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/msbuild/MSBuildCommand/options_fr.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/msbuild/MSBuildCommand/options_fr.properties
@@ -1,2 +1,3 @@
 Configuration=Configuration
-Warnings\ Result\ in\ Unstable\ Build=Des avertissements rendent la construction instable
+Errors\ Result\ in\ Unstable\ Build=Des erreurs rendent le build instable
+Warnings\ Result\ in\ Unstable\ Build=Des avertissements rendent le build instable

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/msbuild/MSBuildCommand/options_nl.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/msbuild/MSBuildCommand/options_nl.properties
@@ -1,2 +1,3 @@
 Configuration=Configuratie
+Errors\ Result\ in\ Unstable\ Build=Fouten maken de build onstabiel
 Warnings\ Result\ in\ Unstable\ Build=Waarschuwingen maken de build onstabiel


### PR DESCRIPTION
This adds two new features:
- a `charset` property on commands
  - this may help when the build issues localized messages
  - I could not reproduce the reported issue, so this might not work
- an `unstableIfErrors` property on MSBuild commands
  - this causes build errors to mark the build as unstable instead of failed
