### PR TITLE
JENKINS-68135: Make the build steps optional in free-style projects.

### DIFF
--- a/src/main/java/io/jenkins/plugins/dotnet/commands/CommandDescriptor.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/CommandDescriptor.java
@@ -2,9 +2,11 @@ package io.jenkins.plugins.dotnet.commands;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.ExtensionList;
 import hudson.Util;
 import hudson.model.AbstractProject;
 import hudson.model.AutoCompletionCandidates;
+import hudson.model.FreeStyleProject;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.util.FormValidation;
@@ -239,6 +241,21 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
    * @return {@code true}.
    */
   public final boolean isApplicable(@CheckForNull Class<? extends AbstractProject> jobType) {
+    if (jobType != null && FreeStyleProject.class.isAssignableFrom(jobType)) {
+      final FreeStyleCommandConfiguration configuration = ExtensionList.lookupSingleton(FreeStyleCommandConfiguration.class);
+      return this.isApplicableToFreeStyleProjects(configuration);
+    }
+    return true;
+  }
+
+  /**
+   * Determines whether this command should be made available to freestyle projects.
+   *
+   * @param configuration The applicable configuration.
+   *
+   * @return {@code true} when the command should be available for use in freestyle projects; {@code false} otherwise.
+   */
+  protected boolean isApplicableToFreeStyleProjects(@NonNull FreeStyleCommandConfiguration configuration) {
     return true;
   }
 

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/FreeStyleCommandConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/FreeStyleCommandConfiguration.java
@@ -1,0 +1,277 @@
+package io.jenkins.plugins.dotnet.commands;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import jenkins.model.GlobalConfiguration;
+import jenkins.model.GlobalConfigurationCategory;
+import jenkins.tools.ToolConfigurationCategory;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import java.io.Serializable;
+
+@Extension
+public class FreeStyleCommandConfiguration extends GlobalConfiguration implements Serializable {
+
+  private static final long serialVersionUID = 7543404699990461923L;
+
+  @DataBoundConstructor
+  public FreeStyleCommandConfiguration() {
+    super();
+    this.load();
+  }
+
+  @NonNull
+  @Override
+  public GlobalConfigurationCategory getCategory() {
+    return GlobalConfigurationCategory.get(ToolConfigurationCategory.class);
+  }
+
+  @Override
+  public String getConfigPage() {
+    return super.getConfigPage();
+  }
+
+  private boolean buildAllowed = true;
+
+  /**
+   * Determines whether the "build" command should be available for use in freestyle projects.
+   *
+   * @return {@code true} if the command should be available; {@code false} otherwise.
+   */
+  public boolean isBuildAllowed() {
+    return this.buildAllowed;
+  }
+
+  /**
+   * Determines whether the "build" command should be available for use in freestyle projects.
+   *
+   * @param allowed {@code true} if the command should be available; {@code false} otherwise.
+   */
+  @DataBoundSetter
+  public void setBuildAllowed(boolean allowed) {
+    this.buildAllowed = allowed;
+    this.save();
+  }
+
+  private boolean cleanAllowed = true;
+
+  /**
+   * Determines whether the "clean" command should be available for use in freestyle projects.
+   *
+   * @return {@code true} if the command should be available; {@code false} otherwise.
+   */
+  public boolean isCleanAllowed() {
+    return this.cleanAllowed;
+  }
+
+  /**
+   * Determines whether the "clean" command should be available for use in freestyle projects.
+   *
+   * @param allowed {@code true} if the command should be available; {@code false} otherwise.
+   */
+  @DataBoundSetter
+  public void setCleanAllowed(boolean allowed) {
+    this.cleanAllowed = allowed;
+    this.save();
+  }
+
+  private boolean listPackageAllowed = true;
+
+  /**
+   * Determines whether the "list package" command should be available for use in freestyle projects.
+   *
+   * @return {@code true} if the command should be available; {@code false} otherwise.
+   */
+  public boolean isListPackageAllowed() {
+    return this.listPackageAllowed;
+  }
+
+  /**
+   * Determines whether the "list package" command should be available for use in freestyle projects.
+   *
+   * @param allowed {@code true} if the command should be available; {@code false} otherwise.
+   */
+  @DataBoundSetter
+  public void setListPackageAllowed(boolean allowed) {
+    this.listPackageAllowed = allowed;
+    this.save();
+  }
+
+  private boolean nuGetDeleteAllowed = true;
+
+  /**
+   * Determines whether the "nuget delete" command should be available for use in freestyle projects.
+   *
+   * @return {@code true} if the command should be available; {@code false} otherwise.
+   */
+  public boolean isNuGetDeleteAllowed() {
+    return this.nuGetDeleteAllowed;
+  }
+
+  /**
+   * Determines whether the "nuget delete" command should be available for use in freestyle projects.
+   *
+   * @param allowed {@code true} if the command should be available; {@code false} otherwise.
+   */
+  @DataBoundSetter
+  public void setNuGetDeleteAllowed(boolean allowed) {
+    this.nuGetDeleteAllowed = allowed;
+    this.save();
+  }
+
+  private boolean nuGetLocalsAllowed = true;
+
+  /**
+   * Determines whether the "nuget locals" command should be available for use in freestyle projects.
+   *
+   * @return {@code true} if the command should be available; {@code false} otherwise.
+   */
+  public boolean isNuGetLocalsAllowed() {
+    return this.nuGetLocalsAllowed;
+  }
+
+  /**
+   * Determines whether the "nuget locals" command should be available for use in freestyle projects.
+   *
+   * @param allowed {@code true} if the command should be available; {@code false} otherwise.
+   */
+  @DataBoundSetter
+  public void setNuGetLocalsAllowed(boolean allowed) {
+    this.nuGetLocalsAllowed = allowed;
+    this.save();
+  }
+
+  private boolean nuGetPushAllowed = true;
+
+  /**
+   * Determines whether the "nuget push" command should be available for use in freestyle projects.
+   *
+   * @return {@code true} if the command should be available; {@code false} otherwise.
+   */
+  public boolean isNuGetPushAllowed() {
+    return this.nuGetPushAllowed;
+  }
+
+  /**
+   * Determines whether the "nuget push" command should be available for use in freestyle projects.
+   *
+   * @param allowed {@code true} if the command should be available; {@code false} otherwise.
+   */
+  @DataBoundSetter
+  public void setNuGetPushAllowed(boolean allowed) {
+    this.nuGetPushAllowed = allowed;
+    this.save();
+  }
+
+  private boolean packAllowed = true;
+
+  /**
+   * Determines whether the "pack" command should be available for use in freestyle projects.
+   *
+   * @return {@code true} if the command should be available; {@code false} otherwise.
+   */
+  public boolean isPackAllowed() {
+    return this.packAllowed;
+  }
+
+  /**
+   * Determines whether the "pack" command should be available for use in freestyle projects.
+   *
+   * @param allowed {@code true} if the command should be available; {@code false} otherwise.
+   */
+  @DataBoundSetter
+  public void setPackAllowed(boolean allowed) {
+    this.packAllowed = allowed;
+    this.save();
+  }
+
+  private boolean publishAllowed = true;
+
+  /**
+   * Determines whether the "publish" command should be available for use in freestyle projects.
+   *
+   * @return {@code true} if the command should be available; {@code false} otherwise.
+   */
+  public boolean isPublishAllowed() {
+    return this.publishAllowed;
+  }
+
+  /**
+   * Determines whether the "publish" command should be available for use in freestyle projects.
+   *
+   * @param allowed {@code true} if the command should be available; {@code false} otherwise.
+   */
+  @DataBoundSetter
+  public void setPublishAllowed(boolean allowed) {
+    this.publishAllowed = allowed;
+    this.save();
+  }
+
+  private boolean restoreAllowed = true;
+
+  /**
+   * Determines whether the "restore" command should be available for use in freestyle projects.
+   *
+   * @return {@code true} if the command should be available; {@code false} otherwise.
+   */
+  public boolean isRestoreAllowed() {
+    return this.restoreAllowed;
+  }
+
+  /**
+   * Determines whether the "restore" command should be available for use in freestyle projects.
+   *
+   * @param allowed {@code true} if the command should be available; {@code false} otherwise.
+   */
+  @DataBoundSetter
+  public void setRestoreAllowed(boolean allowed) {
+    this.restoreAllowed = allowed;
+    this.save();
+  }
+
+  private boolean testAllowed = true;
+
+  /**
+   * Determines whether the "test" command should be available for use in freestyle projects.
+   *
+   * @return {@code true} if the command should be available; {@code false} otherwise.
+   */
+  public boolean isTestAllowed() {
+    return this.testAllowed;
+  }
+
+  /**
+   * Determines whether the "test" command should be available for use in freestyle projects.
+   *
+   * @param allowed {@code true} if the command should be available; {@code false} otherwise.
+   */
+  @DataBoundSetter
+  public void setTestAllowed(boolean allowed) {
+    this.testAllowed = allowed;
+    this.save();
+  }
+
+  private boolean toolRestoreAllowed = true;
+
+  /**
+   * Determines whether the "tool restore" command should be available for use in freestyle projects.
+   *
+   * @return {@code true} if the command should be available; {@code false} otherwise.
+   */
+  public boolean isToolRestoreAllowed() {
+    return this.toolRestoreAllowed;
+  }
+
+  /**
+   * Determines whether the "tool restore" command should be available for use in freestyle projects.
+   *
+   * @param allowed {@code true} if the command should be available; {@code false} otherwise.
+   */
+  @DataBoundSetter
+  public void setToolRestoreAllowed(boolean allowed) {
+    this.toolRestoreAllowed = allowed;
+    this.save();
+  }
+
+}

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/FreeStyleCommandConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/FreeStyleCommandConfiguration.java
@@ -353,7 +353,7 @@ public class FreeStyleCommandConfiguration extends GlobalConfiguration implement
     if (uses == 0) {
       return FormValidation.ok();
     }
-    return FormValidation.warning("This build step is currently in use by %d project(s). (These will continue to function.)", uses);
+    return FormValidation.warning(Messages.FreeStyleCommandConfiguration_StillInUse(uses));
   }
 
   private static boolean includesCommand(@NonNull FreeStyleProject project, @NonNull Class<? extends Command> command) {

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/ListPackage.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/ListPackage.java
@@ -11,6 +11,7 @@ import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.verb.POST;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -433,6 +434,31 @@ public final class ListPackage extends Command {
       this.load();
     }
 
+    @NonNull
+    @Override
+    public UninstantiatedDescribable customUninstantiate(@NonNull UninstantiatedDescribable ud) {
+      ud = super.customUninstantiate(ud);
+      final Map<String, ?> oldArgs = ud.getArguments();
+      final Map<String, Object> newArgs = new HashMap<>();
+      for (final Map.Entry<String, ?> arg : oldArgs.entrySet()) {
+        final String name = arg.getKey();
+        if ("frameworks".equals(name) && oldArgs.containsKey("framework")) {
+          continue;
+        }
+        if ("frameworksString".equals(name)) {
+          continue;
+        }
+        if ("sources".equals(name) && oldArgs.containsKey("source")) {
+          continue;
+        }
+        if ("sourcesString".equals(name)) {
+          continue;
+        }
+        newArgs.put(name, arg.getValue());
+      }
+      return new UninstantiatedDescribable(ud.getSymbol(), ud.getKlass(), newArgs);
+    }
+
     /**
      * Performs validation on the "config file" setting.
      *
@@ -444,9 +470,11 @@ public final class ListPackage extends Command {
      */
     @SuppressWarnings("unused")
     @NonNull
-    public FormValidation doCheckConfig(@CheckForNull @QueryParameter String value, @QueryParameter boolean deprecated, @QueryParameter boolean outdated) {
-      if (Util.fixEmptyAndTrim(value) != null && !deprecated && !outdated)
+    public FormValidation doCheckConfig(@CheckForNull @QueryParameter String value, @QueryParameter boolean deprecated,
+                                        @QueryParameter boolean outdated) {
+      if (Util.fixEmptyAndTrim(value) != null && !deprecated && !outdated) {
         return FormValidation.warning(Messages.ListPackage_OnlyForPackageUpdateSearch());
+      }
       return FormValidation.ok();
     }
 
@@ -461,8 +489,9 @@ public final class ListPackage extends Command {
     @SuppressWarnings("unused")
     @NonNull
     public FormValidation doCheckDeprecated(@QueryParameter boolean deprecated, @QueryParameter boolean outdated) {
-      if (deprecated && outdated)
+      if (deprecated && outdated) {
         return FormValidation.error(Messages.ListPackage_EitherDeprecatedOrOutdated());
+      }
       return FormValidation.ok();
     }
 
@@ -477,9 +506,11 @@ public final class ListPackage extends Command {
      */
     @SuppressWarnings("unused")
     @NonNull
-    public FormValidation doCheckHighestMinor(@QueryParameter boolean value, @QueryParameter boolean deprecated, @QueryParameter boolean outdated) {
-      if (value && !deprecated && !outdated)
+    public FormValidation doCheckHighestMinor(@QueryParameter boolean value, @QueryParameter boolean deprecated,
+                                              @QueryParameter boolean outdated) {
+      if (value && !deprecated && !outdated) {
         return FormValidation.warning(Messages.ListPackage_OnlyForPackageUpdateSearch());
+      }
       return FormValidation.ok();
     }
 
@@ -494,9 +525,11 @@ public final class ListPackage extends Command {
      */
     @SuppressWarnings("unused")
     @NonNull
-    public FormValidation doCheckHighestPatch(@QueryParameter boolean value, @QueryParameter boolean deprecated, @QueryParameter boolean outdated) {
-      if (value && !deprecated && !outdated)
+    public FormValidation doCheckHighestPatch(@QueryParameter boolean value, @QueryParameter boolean deprecated,
+                                              @QueryParameter boolean outdated) {
+      if (value && !deprecated && !outdated) {
         return FormValidation.warning(Messages.ListPackage_OnlyForPackageUpdateSearch());
+      }
       return FormValidation.ok();
     }
 
@@ -511,9 +544,11 @@ public final class ListPackage extends Command {
      */
     @SuppressWarnings("unused")
     @NonNull
-    public FormValidation doCheckIncludePrerelease(@QueryParameter boolean value, @QueryParameter boolean deprecated, @QueryParameter boolean outdated) {
-      if (value && !deprecated && !outdated)
+    public FormValidation doCheckIncludePrerelease(@QueryParameter boolean value, @QueryParameter boolean deprecated,
+                                                   @QueryParameter boolean outdated) {
+      if (value && !deprecated && !outdated) {
         return FormValidation.warning(Messages.ListPackage_OnlyForPackageUpdateSearch());
+      }
       return FormValidation.ok();
     }
 
@@ -528,8 +563,9 @@ public final class ListPackage extends Command {
     @SuppressWarnings("unused")
     @NonNull
     public FormValidation doCheckOutdated(@QueryParameter boolean deprecated, @QueryParameter boolean outdated) {
-      if (deprecated && outdated)
+      if (deprecated && outdated) {
         return FormValidation.error(Messages.ListPackage_EitherDeprecatedOrOutdated());
+      }
       return FormValidation.ok();
     }
 
@@ -544,9 +580,11 @@ public final class ListPackage extends Command {
      */
     @SuppressWarnings("unused")
     @NonNull
-    public FormValidation doCheckSourcesString(@CheckForNull @QueryParameter String value, @QueryParameter boolean deprecated, @QueryParameter boolean outdated) {
-      if (Util.fixEmptyAndTrim(value) != null && !deprecated && !outdated)
+    public FormValidation doCheckSourcesString(@CheckForNull @QueryParameter String value, @QueryParameter boolean deprecated,
+                                               @QueryParameter boolean outdated) {
+      if (Util.fixEmptyAndTrim(value) != null && !deprecated && !outdated) {
         return FormValidation.warning(Messages.ListPackage_OnlyForPackageUpdateSearch());
+      }
       return FormValidation.ok();
     }
 
@@ -560,25 +598,9 @@ public final class ListPackage extends Command {
       return Messages.ListPackage_DisplayName();
     }
 
-    @NonNull
     @Override
-    public UninstantiatedDescribable customUninstantiate(@NonNull UninstantiatedDescribable ud) {
-      ud = super.customUninstantiate(ud);
-      final Map<String, ?> oldArgs = ud.getArguments();
-      final Map<String, Object> newArgs = new HashMap<>();
-      for (final Map.Entry<String, ?> arg : oldArgs.entrySet()) {
-        final String name = arg.getKey();
-        if ("frameworks".equals(name) && oldArgs.containsKey("framework"))
-          continue;
-        if ("frameworksString".equals(name))
-          continue;
-        if ("sources".equals(name) && oldArgs.containsKey("source"))
-          continue;
-        if ("sourcesString".equals(name))
-          continue;
-        newArgs.put(name, arg.getValue());
-      }
-      return new UninstantiatedDescribable(ud.getSymbol(), ud.getKlass(), newArgs);
+    protected boolean isApplicableToFreeStyleProjects(@NonNull FreeStyleCommandConfiguration configuration) {
+      return configuration.isListPackageAllowed();
     }
 
   }

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/Restore.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/Restore.java
@@ -491,6 +491,31 @@ public final class Restore extends Command {
       this.load();
     }
 
+    @NonNull
+    @Override
+    public UninstantiatedDescribable customUninstantiate(@NonNull UninstantiatedDescribable ud) {
+      ud = super.customUninstantiate(ud);
+      final Map<String, ?> oldArgs = ud.getArguments();
+      final Map<String, Object> newArgs = new HashMap<>();
+      for (final Map.Entry<String, ?> arg : oldArgs.entrySet()) {
+        final String name = arg.getKey();
+        if ("runtimes".equals(name) && oldArgs.containsKey("runtime")) {
+          continue;
+        }
+        if ("runtimesString".equals(name)) {
+          continue;
+        }
+        if ("sources".equals(name) && oldArgs.containsKey("source")) {
+          continue;
+        }
+        if ("sourcesString".equals(name)) {
+          continue;
+        }
+        newArgs.put(name, arg.getValue());
+      }
+      return new UninstantiatedDescribable(ud.getSymbol(), ud.getKlass(), newArgs);
+    }
+
     /**
      * Gets the display name for this build step (as used in the project configuration UI).
      *
@@ -501,25 +526,9 @@ public final class Restore extends Command {
       return Messages.Restore_DisplayName();
     }
 
-    @NonNull
     @Override
-    public UninstantiatedDescribable customUninstantiate(@NonNull UninstantiatedDescribable ud) {
-      ud = super.customUninstantiate(ud);
-      final Map<String, ?> oldArgs = ud.getArguments();
-      final Map<String, Object> newArgs = new HashMap<>();
-      for (final Map.Entry<String, ?> arg : oldArgs.entrySet()) {
-        final String name = arg.getKey();
-        if ("runtimes".equals(name) && oldArgs.containsKey("runtime"))
-          continue;
-        if ("runtimesString".equals(name))
-          continue;
-        if ("sources".equals(name) && oldArgs.containsKey("source"))
-          continue;
-        if ("sourcesString".equals(name))
-          continue;
-        newArgs.put(name, arg.getValue());
-      }
-      return new UninstantiatedDescribable(ud.getSymbol(), ud.getKlass(), newArgs);
+    protected boolean isApplicableToFreeStyleProjects(@NonNull FreeStyleCommandConfiguration configuration) {
+      return configuration.isRestoreAllowed();
     }
 
   }

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Build.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Build.java
@@ -6,6 +6,7 @@ import hudson.Extension;
 import hudson.Util;
 import io.jenkins.plugins.dotnet.DotNetUtils;
 import io.jenkins.plugins.dotnet.commands.DotNetArguments;
+import io.jenkins.plugins.dotnet.commands.FreeStyleCommandConfiguration;
 import io.jenkins.plugins.dotnet.commands.Messages;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable;
@@ -288,16 +289,6 @@ public final class Build extends MSBuildCommand {
       this.load();
     }
 
-    /**
-     * Gets the display name for this build step (as used in the project configuration UI).
-     *
-     * @return This build step's display name.
-     */
-    @NonNull
-    public String getDisplayName() {
-      return Messages.MSBuild_Build_DisplayName();
-    }
-
     @NonNull
     @Override
     public UninstantiatedDescribable customUninstantiate(@NonNull UninstantiatedDescribable ud) {
@@ -313,6 +304,21 @@ public final class Build extends MSBuildCommand {
         newArgs.put(name, arg.getValue());
       }
       return new UninstantiatedDescribable(ud.getSymbol(), ud.getKlass(), newArgs);
+    }
+
+    /**
+     * Gets the display name for this build step (as used in the project configuration UI).
+     *
+     * @return This build step's display name.
+     */
+    @NonNull
+    public String getDisplayName() {
+      return Messages.MSBuild_Build_DisplayName();
+    }
+
+    @Override
+    protected boolean isApplicableToFreeStyleProjects(@NonNull FreeStyleCommandConfiguration configuration) {
+      return configuration.isBuildAllowed();
     }
 
   }

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Clean.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Clean.java
@@ -5,6 +5,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import io.jenkins.plugins.dotnet.commands.DotNetArguments;
+import io.jenkins.plugins.dotnet.commands.FreeStyleCommandConfiguration;
 import io.jenkins.plugins.dotnet.commands.Messages;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -104,6 +105,11 @@ public final class Clean extends MSBuildCommand {
     @NonNull
     public String getDisplayName() {
       return Messages.MSBuild_Clean_DisplayName();
+    }
+
+    @Override
+    protected boolean isApplicableToFreeStyleProjects(@NonNull FreeStyleCommandConfiguration configuration) {
+      return configuration.isCleanAllowed();
     }
 
   }

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Pack.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Pack.java
@@ -5,6 +5,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import io.jenkins.plugins.dotnet.commands.DotNetArguments;
+import io.jenkins.plugins.dotnet.commands.FreeStyleCommandConfiguration;
 import io.jenkins.plugins.dotnet.commands.Messages;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -243,6 +244,11 @@ public final class Pack extends MSBuildCommand {
     @NonNull
     public String getDisplayName() {
       return Messages.MSBuild_Pack_DisplayName();
+    }
+
+    @Override
+    protected boolean isApplicableToFreeStyleProjects(@NonNull FreeStyleCommandConfiguration configuration) {
+      return configuration.isPackAllowed();
     }
 
   }

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Publish.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Publish.java
@@ -7,6 +7,7 @@ import hudson.Util;
 import hudson.util.ListBoxModel;
 import io.jenkins.plugins.dotnet.DotNetUtils;
 import io.jenkins.plugins.dotnet.commands.DotNetArguments;
+import io.jenkins.plugins.dotnet.commands.FreeStyleCommandConfiguration;
 import io.jenkins.plugins.dotnet.commands.Messages;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable;
@@ -311,6 +312,25 @@ public final class Publish extends MSBuildCommand {
       this.load();
     }
 
+    @NonNull
+    @Override
+    public UninstantiatedDescribable customUninstantiate(@NonNull UninstantiatedDescribable ud) {
+      ud = super.customUninstantiate(ud);
+      final Map<String, ?> oldArgs = ud.getArguments();
+      final Map<String, Object> newArgs = new HashMap<>();
+      for (final Map.Entry<String, ?> arg : oldArgs.entrySet()) {
+        final String name = arg.getKey();
+        if ("manifests".equals(name) && oldArgs.containsKey("manifest")) {
+          continue;
+        }
+        if ("manifestsString".equals(name)) {
+          continue;
+        }
+        newArgs.put(name, arg.getValue());
+      }
+      return new UninstantiatedDescribable(ud.getSymbol(), ud.getKlass(), newArgs);
+    }
+
     /**
      * Fills a listbox with the possible values for the "self-containing" setting.
      *
@@ -336,21 +356,9 @@ public final class Publish extends MSBuildCommand {
       return Messages.MSBuild_Publish_DisplayName();
     }
 
-    @NonNull
     @Override
-    public UninstantiatedDescribable customUninstantiate(@NonNull UninstantiatedDescribable ud) {
-      ud = super.customUninstantiate(ud);
-      final Map<String, ?> oldArgs = ud.getArguments();
-      final Map<String, Object> newArgs = new HashMap<>();
-      for (final Map.Entry<String, ?> arg : oldArgs.entrySet()) {
-        final String name = arg.getKey();
-        if ("manifests".equals(name) && oldArgs.containsKey("manifest"))
-          continue;
-        if ("manifestsString".equals(name))
-          continue;
-        newArgs.put(name, arg.getValue());
-      }
-      return new UninstantiatedDescribable(ud.getSymbol(), ud.getKlass(), newArgs);
+    protected boolean isApplicableToFreeStyleProjects(@NonNull FreeStyleCommandConfiguration configuration) {
+      return configuration.isPublishAllowed();
     }
 
   }

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Test.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Test.java
@@ -8,6 +8,7 @@ import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import io.jenkins.plugins.dotnet.DotNetUtils;
 import io.jenkins.plugins.dotnet.commands.DotNetArguments;
+import io.jenkins.plugins.dotnet.commands.FreeStyleCommandConfiguration;
 import io.jenkins.plugins.dotnet.commands.Messages;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable;
@@ -579,8 +580,9 @@ public final class Test extends MSBuildCommand {
       final Map<String, Object> args = new HashMap<>();
       for (final Map.Entry<String, ?> arg : ud.getArguments().entrySet()) {
         final String name = arg.getKey();
-        if ("runSettingsString".equals(name))
+        if ("runSettingsString".equals(name)) {
           continue;
+        }
         args.put(name, arg.getValue());
       }
       return new UninstantiatedDescribable(ud.getSymbol(), ud.getKlass(), args);
@@ -596,10 +598,12 @@ public final class Test extends MSBuildCommand {
     @SuppressWarnings("unused")
     @NonNull
     public FormValidation doCheckBlameHangTimeout(@CheckForNull @QueryParameter Integer value) {
-      if (value == null)
+      if (value == null) {
         return FormValidation.ok();
-      if (value < 0)
+      }
+      if (value < 0) {
         return FormValidation.error(Messages.MSBuild_Test_InvalidTimeout());
+      }
       final StringBuilder sb = new StringBuilder();
       int ms = value;
       if (ms > 3600000) {
@@ -607,13 +611,15 @@ public final class Test extends MSBuildCommand {
         ms %= 3600000;
       }
       if (ms > 60000) {
-        if (sb.length() > 0)
+        if (sb.length() > 0) {
           sb.append(' ');
+        }
         sb.append(String.format("%dm", ms / 60000));
         ms %= 60000;
       }
-      if (sb.length() > 0)
+      if (sb.length() > 0) {
         sb.append(' ');
+      }
       sb.append(String.format("%.3fs", ms / 1000.0));
       return FormValidation.ok(sb.toString());
     }
@@ -679,6 +685,11 @@ public final class Test extends MSBuildCommand {
     @NonNull
     public String getDisplayName() {
       return Messages.MSBuild_Test_DisplayName();
+    }
+
+    @Override
+    protected boolean isApplicableToFreeStyleProjects(@NonNull FreeStyleCommandConfiguration configuration) {
+      return configuration.isTestAllowed();
     }
 
   }

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/nuget/Delete.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/nuget/Delete.java
@@ -8,6 +8,7 @@ import hudson.Util;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import io.jenkins.plugins.dotnet.DotNetUtils;
+import io.jenkins.plugins.dotnet.commands.FreeStyleCommandConfiguration;
 import io.jenkins.plugins.dotnet.commands.DotNetArguments;
 import io.jenkins.plugins.dotnet.commands.Messages;
 import jenkins.model.Jenkins;
@@ -80,24 +81,30 @@ public final class Delete extends DeleteOrPush {
       this.load();
     }
 
+    @SuppressWarnings("unused")
     public FormValidation doCheckPackageName(@QueryParameter String value) {
       value = Util.fixEmptyAndTrim(value);
       // TODO: Maybe do some basic semantic version validation?
-      if (value != null && value.split(" \r\t\n", 2).length != 1)
+      if (value != null && value.split(" \r\t\n", 2).length != 1) {
         return FormValidation.error(Messages.NuGet_Delete_InvalidPackageName());
+      }
       return FormValidation.ok();
     }
 
+    @SuppressWarnings("unused")
     public FormValidation doCheckPackageVersion(@QueryParameter String value, @QueryParameter String packageName) {
       value = Util.fixEmptyAndTrim(value);
       // TODO: Maybe do some basic semantic version validation?
-      if (value != null && value.split(" \r\t\n", 2).length != 1)
+      if (value != null && value.split(" \r\t\n", 2).length != 1) {
         return FormValidation.error(Messages.NuGet_Delete_InvalidPackageVersion());
+      }
       packageName = Util.fixEmptyAndTrim(packageName);
-      if (packageName == null && value != null)
+      if (packageName == null && value != null) {
         return FormValidation.warning(Messages.NuGet_Delete_PackageVersionWithoutName());
-      if (packageName != null && value == null)
+      }
+      if (packageName != null && value == null) {
         return FormValidation.error(Messages.NuGet_Delete_PackageNameWithoutVersion());
+      }
       return FormValidation.ok();
     }
 
@@ -115,6 +122,11 @@ public final class Delete extends DeleteOrPush {
     @NonNull
     public String getDisplayName() {
       return Messages.NuGet_Delete_DisplayName();
+    }
+
+    @Override
+    protected boolean isApplicableToFreeStyleProjects(@NonNull FreeStyleCommandConfiguration configuration) {
+      return configuration.isNuGetDeleteAllowed();
     }
 
   }

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/nuget/Locals.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/nuget/Locals.java
@@ -4,6 +4,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.AbortException;
 import hudson.Extension;
 import hudson.util.ListBoxModel;
+import io.jenkins.plugins.dotnet.commands.FreeStyleCommandConfiguration;
 import io.jenkins.plugins.dotnet.commands.DotNetArguments;
 import io.jenkins.plugins.dotnet.commands.Messages;
 import org.jenkinsci.Symbol;
@@ -124,6 +125,11 @@ public final class Locals extends NuGetCommand {
     @NonNull
     public String getDisplayName() {
       return Messages.NuGet_Locals_DisplayName();
+    }
+
+    @Override
+    protected boolean isApplicableToFreeStyleProjects(@NonNull FreeStyleCommandConfiguration configuration) {
+      return configuration.isNuGetLocalsAllowed();
     }
 
   }

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/nuget/Push.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/nuget/Push.java
@@ -7,6 +7,7 @@ import hudson.Extension;
 import hudson.Util;
 import hudson.util.ListBoxModel;
 import io.jenkins.plugins.dotnet.DotNetUtils;
+import io.jenkins.plugins.dotnet.commands.FreeStyleCommandConfiguration;
 import io.jenkins.plugins.dotnet.commands.DotNetArguments;
 import io.jenkins.plugins.dotnet.commands.Messages;
 import jenkins.model.Jenkins;
@@ -149,8 +150,9 @@ public final class Push extends DeleteOrPush {
 
   @DataBoundSetter
   public void setTimeout(Integer timeout) {
-    if (timeout != null && timeout <= 0)
+    if (timeout != null && timeout <= 0) {
       timeout = null;
+    }
     this.timeout = timeout;
   }
 
@@ -188,6 +190,11 @@ public final class Push extends DeleteOrPush {
     @NonNull
     public String getDisplayName() {
       return Messages.NuGet_Push_DisplayName();
+    }
+
+    @Override
+    protected boolean isApplicableToFreeStyleProjects(@NonNull FreeStyleCommandConfiguration configuration) {
+      return configuration.isNuGetPushAllowed();
     }
 
   }

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/tool/Restore.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/tool/Restore.java
@@ -7,6 +7,7 @@ import hudson.Extension;
 import hudson.Util;
 import io.jenkins.plugins.dotnet.DotNetUtils;
 import io.jenkins.plugins.dotnet.commands.DotNetArguments;
+import io.jenkins.plugins.dotnet.commands.FreeStyleCommandConfiguration;
 import io.jenkins.plugins.dotnet.commands.Messages;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable;
@@ -259,6 +260,25 @@ public final class Restore extends ToolCommand {
       this.load();
     }
 
+    @NonNull
+    @Override
+    public UninstantiatedDescribable customUninstantiate(@NonNull UninstantiatedDescribable ud) {
+      ud = super.customUninstantiate(ud);
+      final Map<String, ?> oldArgs = ud.getArguments();
+      final Map<String, Object> newArgs = new HashMap<>();
+      for (final Map.Entry<String, ?> arg : oldArgs.entrySet()) {
+        final String name = arg.getKey();
+        if ("additionalSources".equals(name) && oldArgs.containsKey("additionalSource")) {
+          continue;
+        }
+        if ("additionalSourcesString".equals(name)) {
+          continue;
+        }
+        newArgs.put(name, arg.getValue());
+      }
+      return new UninstantiatedDescribable(ud.getSymbol(), ud.getKlass(), newArgs);
+    }
+
     /**
      * Gets the display name for this build step (as used in the project configuration UI).
      *
@@ -269,23 +289,10 @@ public final class Restore extends ToolCommand {
       return Messages.Tool_Restore_DisplayName();
     }
 
-    @NonNull
     @Override
-    public UninstantiatedDescribable customUninstantiate(@NonNull UninstantiatedDescribable ud) {
-      ud = super.customUninstantiate(ud);
-      final Map<String, ?> oldArgs = ud.getArguments();
-      final Map<String, Object> newArgs = new HashMap<>();
-      for (final Map.Entry<String, ?> arg : oldArgs.entrySet()) {
-        final String name = arg.getKey();
-        if ("additionalSources".equals(name) && oldArgs.containsKey("additionalSource"))
-          continue;
-        if ("additionalSourcesString".equals(name))
-          continue;
-        newArgs.put(name, arg.getValue());
-      }
-      return new UninstantiatedDescribable(ud.getSymbol(), ud.getKlass(), newArgs);
+    protected boolean isApplicableToFreeStyleProjects(@NonNull FreeStyleCommandConfiguration configuration) {
+      return configuration.isToolRestoreAllowed();
     }
-
   }
 
   //endregion

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/FreeStyleCommandConfiguration/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/FreeStyleCommandConfiguration/config.jelly
@@ -1,0 +1,64 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:s="jelly:stapler">
+
+  <f:section title="${%Section.Name}">
+
+    <!-- Unfortunately, "help.html" is not automatically applied to the section, so use resource messages. -->
+    <div>
+      ${%Section.Help1}
+    </div>
+    <div>
+      ${%Section.Help2}
+      ${%Section.Help3}
+    </div>
+    <div>
+      ${%Section.Help4}
+    </div>
+
+    <f:entry title="dotnet build" field="buildAllowed">
+      <f:checkbox/>
+    </f:entry>
+
+    <f:entry title="dotnet clean" field="cleanAllowed">
+      <f:checkbox/>
+    </f:entry>
+
+    <f:entry title="dotnet list package" field="listPackageAllowed">
+      <f:checkbox/>
+    </f:entry>
+
+    <f:entry title="dotnet nuget delete" field="nuGetDeleteAllowed">
+      <f:checkbox/>
+    </f:entry>
+
+    <f:entry title="dotnet nuget locals" field="nuGetLocalsAllowed">
+      <f:checkbox/>
+    </f:entry>
+
+    <f:entry title="dotnet nuget push" field="nuGetPushAllowed">
+      <f:checkbox/>
+    </f:entry>
+
+    <f:entry title="dotnet pack" field="packAllowed">
+      <f:checkbox/>
+    </f:entry>
+
+    <f:entry title="dotnet publish" field="publishAllowed">
+      <f:checkbox/>
+    </f:entry>
+
+    <f:entry title="dotnet restore" field="restoreAllowed">
+      <f:checkbox/>
+    </f:entry>
+
+    <f:entry title="dotnet test" field="testAllowed">
+      <f:checkbox/>
+    </f:entry>
+
+    <f:entry title="dotnet tool restore" field="toolRestoreAllowed">
+      <f:checkbox/>
+    </f:entry>
+
+  </f:section>
+
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/FreeStyleCommandConfiguration/config.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/FreeStyleCommandConfiguration/config.properties
@@ -1,0 +1,7 @@
+Section.Name=.NET Build Steps (Freestyle Projects)
+Section.Help1=By default, all build steps provided by the .NET SDK plugin are made available for use both in pipelines and in \
+  freestyle projects.
+Section.Help2=By unchecking specific commands here, their corresponding step will be hidden from freestyle projects (keeping \
+  the list of available steps to a minimum).
+Section.Help3=This does not affect their use in pipelines.
+Section.Help4=The &quot;With .NET&quot; command wrapper always remains available in freestyle projects.

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/FreeStyleCommandConfiguration/config_fr.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/FreeStyleCommandConfiguration/config_fr.properties
@@ -1,0 +1,7 @@
+Section.Name=Étapes .NET (projects free-style)
+Section.Help1=Par défaut, les étapes fournies par le plug-in sont disponibles à la fois dans les pipelines et dans les projets \
+  free-style.
+Section.Help2=En décochant des commandes spécifiques ici, leur étape correspondante sera masquée des projets free-style (réduisant \
+  la liste des étapes disponibles).
+Section.Help3=Ceci n&apos;impacte pas leur utilisation dans les pipelines.
+Section.Help4=Le wrapper &quot;Utiliser .NET&quot; reste toujours disponible dans les projets free-style.

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/FreeStyleCommandConfiguration/config_nl.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/FreeStyleCommandConfiguration/config_nl.properties
@@ -1,0 +1,7 @@
+Section.Name=.NET Stappen ("vrije stijl" projecten)
+Section.Help1=Alle stappen die door de plugin ter beschikking worden gesteld, zijn standaard bruikbaar zowel in pipelines als in \
+  "vrije stijl" projecten.
+Section.Help2=Door specifieke commando&apos;s hier uit te vinken, worden de overeenkomstige stappen verborgen voor "vrije stijl" \
+  projecten (om de configuratie daar beperkt te houden).
+Section.Help3=Dit heeft geen effect op het gebruik van deze stappen in pipelines.
+Section.Help4=De &quot;.NET gebruiken&quot; wrapper blijft altijd beschikbaar in "vrije stijl" projecten.

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/Messages.properties
@@ -12,6 +12,8 @@ Command.Verbosity.Diagnostic=Diagnostic (diag)
 
 DotNetArguments.StringCredentialNotFound=No string credentials found with id "{0}".
 
+FreeStyleCommandConfiguration.StillInUse=This build step is still in use by {0} project(s). (These will continue to function.)
+
 ListPackage.DisplayName=.NET: Show dependencies (list package)
 ListPackage.EitherDeprecatedOrOutdated=Cannot show deprecated and outdated packages at the same time
 ListPackage.OnlyForPackageUpdateSearch=This setting is only used when showing deprecated or outdated packages

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/Messages_fr.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/Messages_fr.properties
@@ -1,16 +1,18 @@
 Command.DefaultSDK=(Défaut)
 Command.ExecutionFailed=L'exécution de l'ordre a échoué
-Command.MoreOptions=Options additionelles
+Command.MoreOptions=Options additionnelles
 Command.SameCharsetAsBuild=Identique au reste du build
 Command.UnsupportedCharset=Jeu de caractères non supporté
 Command.Verbosity.Default=(Défaut)
 Command.Verbosity.Quiet=Silencieux (q)
 Command.Verbosity.Minimal=Minimale (m)
 Command.Verbosity.Normal=Normale (n)
-Command.Verbosity.Detailed=Detaillé (d)
+Command.Verbosity.Detailed=Détaillé (d)
 Command.Verbosity.Diagnostic=Diagnostique (diag)
 
 DotNetArguments.StringCredentialNotFound=Aucune information d'identification trouvée avec identifiant «{0}».
+
+FreeStyleCommandConfiguration.StillInUse=Cette étape est toujours utilisée par {0} projet(s). (Ceux-ci continueront à fonctionner.)
 
 ListPackage.DisplayName=.NET: Afficher les dépendances (list package)
 ListPackage.EitherDeprecatedOrOutdated=Impossible d'afficher les paquets rappelés et désuets en même temps
@@ -38,7 +40,7 @@ MSBuild.Test.InvalidTimeout=Le délai d'attente ne peut pas être négatif
 NuGet.Delete.DisplayName=.NET: Supprimer/Délister un package NuGet (nuget delete)
 NuGet.Delete.InvalidPackageName=Spécification incorrecte du nom du package.
 NuGet.Delete.InvalidPackageVersion=Spécification incorrecte de la version du package.
-NuGet.Delete.PackageVersionWithoutName=Une spécification de version de package est ignorée lorsqu'aucun nom de package n'a été spécifié.
+NuGet.Delete.PackageVersionWithoutName=Une spécification de version de package est ignorée lorsque aucun nom de package n'a été spécifié.
 NuGet.Delete.PackageNameWithoutVersion=Une spécification de version de package est requise lorsqu'un nom de package a été spécifié.
 
 NuGet.Locals.DisplayName=.NET: Supprimer/Afficher les ressources NuGet locales (nuget locals)

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/Messages_nl.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/Messages_nl.properties
@@ -12,6 +12,8 @@ Command.Verbosity.Diagnostic=Diagnostiek (diag)
 
 DotNetArguments.StringCredentialNotFound=Geen authenticatiegegevens gevonden met id "{0}".
 
+FreeStyleCommandConfiguration.StillInUse=Deze bouwstap wordt nog door {0} project(en) gebruikt. (Die zullen wel blijven werken.)
+
 ListPackage.DisplayName=.NET: Afhankelijkheden tonen (list package)
 ListPackage.EitherDeprecatedOrOutdated=Kan afgeschafte en verouderde pakketten niet tegelijkertijd weergeven
 ListPackage.OnlyForPackageUpdateSearch=Enkel gebruikt bij de weergave van afgeschafte of verouderde pakketten


### PR DESCRIPTION
This adds a new piece of global configuration (in the "global tools" category) that allows specifying which of the steps should be made available in freestyle projects. By default, that's all of them.

Fixes JENKINS-68135.
