### PR TITLE
Fix Security Alerts

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="EntryPointsManager">
-    <list size="1">
-      <item index="0" class="java.lang.String" itemvalue="org.kohsuke.stapler.verb.POST" />
+    <list size="3">
+      <item index="0" class="java.lang.String" itemvalue="org.kohsuke.stapler.DataBoundConstructor" />
+      <item index="1" class="java.lang.String" itemvalue="org.kohsuke.stapler.DataBoundSetter" />
+      <item index="2" class="java.lang.String" itemvalue="org.kohsuke.stapler.verb.POST" />
     </list>
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="EntryPointsManager">
+    <list size="1">
+      <item index="0" class="java.lang.String" itemvalue="org.kohsuke.stapler.verb.POST" />
+    </list>
+  </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="MavenProjectsManager">
     <option name="originalFiles">

--- a/src/main/java/io/jenkins/plugins/dotnet/DotNetSDKInstaller.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/DotNetSDKInstaller.java
@@ -15,6 +15,7 @@ import hudson.tools.ToolInstallerDescriptor;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import io.jenkins.plugins.dotnet.data.Downloads;
+import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -204,6 +205,7 @@ public final class DotNetSDKInstaller extends ToolInstaller {
     @NonNull
     @POST
     public AutoCompletionCandidates doAutoCompleteLabel(@CheckForNull @QueryParameter String value) {
+      Jenkins.get().checkPermission(Jenkins.MANAGE);
       return LabelExpression.autoComplete(value);
     }
 
@@ -217,6 +219,7 @@ public final class DotNetSDKInstaller extends ToolInstaller {
     @NonNull
     @POST
     public FormValidation doCheckLabel(@CheckForNull @QueryParameter String value) {
+      Jenkins.get().checkPermission(Jenkins.MANAGE);
       return LabelExpression.validate(value, null);
     }
 
@@ -231,6 +234,7 @@ public final class DotNetSDKInstaller extends ToolInstaller {
     @NonNull
     @POST
     public FormValidation doCheckRelease(@CheckForNull @QueryParameter String version, @CheckForNull @QueryParameter String value) {
+      Jenkins.get().checkPermission(Jenkins.MANAGE);
       if (Util.fixEmpty(version) == null)
         return FormValidation.error(Messages.DotNetSDKInstaller_VersionRequired());
       if (Util.fixEmpty(value) == null)
@@ -257,6 +261,7 @@ public final class DotNetSDKInstaller extends ToolInstaller {
     @POST
     public FormValidation doCheckSdk(@CheckForNull @QueryParameter String version, @CheckForNull @QueryParameter String release,
                                      @CheckForNull @QueryParameter String value) {
+      Jenkins.get().checkPermission(Jenkins.MANAGE);
       if (Util.fixEmpty(version) == null)
         return FormValidation.error(Messages.DotNetSDKInstaller_VersionRequired());
       if (Util.fixEmpty(release) == null)
@@ -285,6 +290,7 @@ public final class DotNetSDKInstaller extends ToolInstaller {
     @POST
     public FormValidation doCheckUrl(@CheckForNull @QueryParameter String version, @CheckForNull @QueryParameter String release,
                                      @CheckForNull @QueryParameter String sdk, @CheckForNull @QueryParameter String value) {
+      Jenkins.get().checkPermission(Jenkins.MANAGE);
       if (Util.fixEmpty(version) == null)
         return FormValidation.error(Messages.DotNetSDKInstaller_VersionRequired());
       if (Util.fixEmpty(release) == null)
@@ -309,6 +315,7 @@ public final class DotNetSDKInstaller extends ToolInstaller {
     @NonNull
     @POST
     public FormValidation doCheckVersion(@CheckForNull @QueryParameter String value) {
+      Jenkins.get().checkPermission(Jenkins.MANAGE);
       if (Util.fixEmpty(value) == null)
         return FormValidation.error(Messages.DotNetSDKInstaller_Required());
       if (Downloads.getInstance().getVersion(value) == null)
@@ -326,6 +333,7 @@ public final class DotNetSDKInstaller extends ToolInstaller {
     @NonNull
     @POST
     public ListBoxModel doFillUrlItems(@CheckForNull @QueryParameter String sdk) {
+      Jenkins.get().checkPermission(Jenkins.MANAGE);
       return Downloads.getInstance().addPackages(this.createList(), sdk);
     }
 
@@ -340,6 +348,7 @@ public final class DotNetSDKInstaller extends ToolInstaller {
     @NonNull
     @POST
     public ListBoxModel doFillReleaseItems(@CheckForNull @QueryParameter String version, @QueryParameter boolean includePreview) {
+      Jenkins.get().checkPermission(Jenkins.MANAGE);
       return Downloads.getInstance().addReleases(this.createList(), version, includePreview);
     }
 
@@ -354,6 +363,7 @@ public final class DotNetSDKInstaller extends ToolInstaller {
     @NonNull
     @POST
     public ListBoxModel doFillSdkItems(@CheckForNull @QueryParameter String version, @CheckForNull @QueryParameter String release) {
+      Jenkins.get().checkPermission(Jenkins.MANAGE);
       return Downloads.getInstance().addSdks(this.createList(), version, release);
     }
 
@@ -363,7 +373,9 @@ public final class DotNetSDKInstaller extends ToolInstaller {
      * @return A suitably filled listbox model.
      */
     @NonNull
+    @POST
     public ListBoxModel doFillVersionItems() {
+      Jenkins.get().checkPermission(Jenkins.MANAGE);
       return Downloads.getInstance().addVersions(this.createList());
     }
 

--- a/src/main/java/io/jenkins/plugins/dotnet/DotNetSDKInstaller.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/DotNetSDKInstaller.java
@@ -19,6 +19,7 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.verb.POST;
 
 import java.io.IOException;
 import java.net.URL;
@@ -185,6 +186,7 @@ public final class DotNetSDKInstaller extends ToolInstaller {
   @Symbol("installDotNetSDK")
   public static final class DescriptorImpl extends ToolInstallerDescriptor<DotNetSDKInstaller> {
 
+    @NonNull
     private ListBoxModel createList() {
       final ListBoxModel model = new ListBoxModel();
       // Setting the value to null does not work - it causes the validation routines to get '"null"', not 'null', as value.
@@ -199,8 +201,8 @@ public final class DotNetSDKInstaller extends ToolInstaller {
      *
      * @return The computed auto-completion candidates.
      */
-    @SuppressWarnings("unused")
     @NonNull
+    @POST
     public AutoCompletionCandidates doAutoCompleteLabel(@CheckForNull @QueryParameter String value) {
       return LabelExpression.autoComplete(value);
     }
@@ -212,8 +214,8 @@ public final class DotNetSDKInstaller extends ToolInstaller {
      *
      * @return The validation result.
      */
-    @SuppressWarnings("unused")
     @NonNull
+    @POST
     public FormValidation doCheckLabel(@CheckForNull @QueryParameter String value) {
       return LabelExpression.validate(value, null);
     }
@@ -226,8 +228,8 @@ public final class DotNetSDKInstaller extends ToolInstaller {
      *
      * @return The validation result.
      */
-    @SuppressWarnings("unused")
     @NonNull
+    @POST
     public FormValidation doCheckRelease(@CheckForNull @QueryParameter String version, @CheckForNull @QueryParameter String value) {
       if (Util.fixEmpty(version) == null)
         return FormValidation.error(Messages.DotNetSDKInstaller_VersionRequired());
@@ -251,9 +253,10 @@ public final class DotNetSDKInstaller extends ToolInstaller {
      *
      * @return The validation result.
      */
-    @SuppressWarnings("unused")
     @NonNull
-    public FormValidation doCheckSdk(@CheckForNull @QueryParameter String version, @CheckForNull @QueryParameter String release, @CheckForNull @QueryParameter String value) {
+    @POST
+    public FormValidation doCheckSdk(@CheckForNull @QueryParameter String version, @CheckForNull @QueryParameter String release,
+                                     @CheckForNull @QueryParameter String value) {
       if (Util.fixEmpty(version) == null)
         return FormValidation.error(Messages.DotNetSDKInstaller_VersionRequired());
       if (Util.fixEmpty(release) == null)
@@ -278,9 +281,10 @@ public final class DotNetSDKInstaller extends ToolInstaller {
      *
      * @return The validation result.
      */
-    @SuppressWarnings("unused")
     @NonNull
-    public FormValidation doCheckUrl(@CheckForNull @QueryParameter String version, @CheckForNull @QueryParameter String release, @CheckForNull @QueryParameter String sdk, @CheckForNull @QueryParameter String value) {
+    @POST
+    public FormValidation doCheckUrl(@CheckForNull @QueryParameter String version, @CheckForNull @QueryParameter String release,
+                                     @CheckForNull @QueryParameter String sdk, @CheckForNull @QueryParameter String value) {
       if (Util.fixEmpty(version) == null)
         return FormValidation.error(Messages.DotNetSDKInstaller_VersionRequired());
       if (Util.fixEmpty(release) == null)
@@ -302,7 +306,8 @@ public final class DotNetSDKInstaller extends ToolInstaller {
      *
      * @return The validation result.
      */
-    @SuppressWarnings("unused")
+    @NonNull
+    @POST
     public FormValidation doCheckVersion(@CheckForNull @QueryParameter String value) {
       if (Util.fixEmpty(value) == null)
         return FormValidation.error(Messages.DotNetSDKInstaller_Required());
@@ -318,8 +323,8 @@ public final class DotNetSDKInstaller extends ToolInstaller {
      *
      * @return A suitably filled listbox model.
      */
-    @SuppressWarnings("unused")
     @NonNull
+    @POST
     public ListBoxModel doFillUrlItems(@CheckForNull @QueryParameter String sdk) {
       return Downloads.getInstance().addPackages(this.createList(), sdk);
     }
@@ -332,8 +337,8 @@ public final class DotNetSDKInstaller extends ToolInstaller {
      *
      * @return A suitably filled listbox model.
      */
-    @SuppressWarnings("unused")
     @NonNull
+    @POST
     public ListBoxModel doFillReleaseItems(@CheckForNull @QueryParameter String version, @QueryParameter boolean includePreview) {
       return Downloads.getInstance().addReleases(this.createList(), version, includePreview);
     }
@@ -346,8 +351,8 @@ public final class DotNetSDKInstaller extends ToolInstaller {
      *
      * @return A suitably filled listbox model.
      */
-    @SuppressWarnings("unused")
     @NonNull
+    @POST
     public ListBoxModel doFillSdkItems(@CheckForNull @QueryParameter String version, @CheckForNull @QueryParameter String release) {
       return Downloads.getInstance().addSdks(this.createList(), version, release);
     }
@@ -357,7 +362,6 @@ public final class DotNetSDKInstaller extends ToolInstaller {
      *
      * @return A suitably filled listbox model.
      */
-    @SuppressWarnings("unused")
     @NonNull
     public ListBoxModel doFillVersionItems() {
       return Downloads.getInstance().addVersions(this.createList());

--- a/src/main/java/io/jenkins/plugins/dotnet/DotNetUtils.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/DotNetUtils.java
@@ -1,6 +1,5 @@
 package io.jenkins.plugins.dotnet;
 
-import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.AbstractIdCredentialsListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
@@ -19,7 +18,6 @@ import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import java.util.function.Supplier;
@@ -128,18 +126,18 @@ public interface DotNetUtils {
   /**
    * Fills a listbox model with all available string credentials.
    *
-   * @param context    The context to use to obtain the credentials.
    * @param allowEmpty Indicates whether to include an empty ("no credential selected") option in the listbox.
    *
    * @return A suitably filled listbox model.
    */
   @NonNull
   @SuppressWarnings("deprecation")
-  static ListBoxModel getStringCredentialsList(@CheckForNull Jenkins context, boolean allowEmpty) {
+  static ListBoxModel getStringCredentialsList(boolean allowEmpty) {
     AbstractIdCredentialsListBoxModel<StandardListBoxModel, StandardCredentials> model = new StandardListBoxModel();
     if (allowEmpty) {
       model = model.includeEmptyValue();
     }
+    final Jenkins context = Jenkins.getInstanceOrNull();
     if (context == null || !context.hasPermission(CredentialsProvider.VIEW)) {
       return model;
     }
@@ -154,6 +152,7 @@ public interface DotNetUtils {
    * @param s A string containing tokens.
    *
    * @return The sole token contained in {@code s}, or {@code null} when it did not contain exactly one token.
+   *
    * @see Util#tokenize(String)
    */
   @CheckForNull
@@ -171,6 +170,7 @@ public interface DotNetUtils {
    * @param delimiters A string containing the delimiters to use.
    *
    * @return The sole token contained in {@code s}, or {@code null} when it did not contain exactly one token.
+   *
    * @see Util#tokenize(String, String)
    */
   @CheckForNull
@@ -187,6 +187,7 @@ public interface DotNetUtils {
    * @param s A string containing tokens.
    *
    * @return The tokens contained in {@code s}, or {@code null} when it did not contain any.
+   *
    * @see Util#tokenize(String)
    */
   @CheckForNull
@@ -206,6 +207,7 @@ public interface DotNetUtils {
    * @param delimiters A string containing the delimiters to use.
    *
    * @return The tokens contained in {@code s}, or {@code null} when it did not contain any.
+   *
    * @see Util#tokenize(String, String)
    */
   @CheckForNull

--- a/src/main/java/io/jenkins/plugins/dotnet/DotNetWrapper.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/DotNetWrapper.java
@@ -10,8 +10,10 @@ import hudson.Launcher;
 import hudson.Util;
 import hudson.console.ConsoleLogFilter;
 import hudson.model.AbstractProject;
+import hudson.model.Item;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.security.Permission;
 import hudson.tasks.BuildWrapperDescriptor;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
@@ -19,6 +21,7 @@ import io.jenkins.plugins.dotnet.console.DiagnosticFilter;
 import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildWrapper;
 import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -80,8 +83,8 @@ public class DotNetWrapper extends SimpleBuildWrapper {
    * most recent SDK version available on the system; with this set, a {@code global.json} file will be created to ensure a specific
    * SDK version gets used.
    *
-   * @param specificSdkVersion {@code true} if {@code global.json} should be used to ensure a specific SDK version gets used; {@code
-   *                           false} otherwise.
+   * @param specificSdkVersion {@code true} if {@code global.json} should be used to ensure a specific SDK version gets used;
+   *                           {@code false} otherwise.
    */
   @DataBoundSetter
   public void setSpecificSdkVersion(boolean specificSdkVersion) {
@@ -168,23 +171,28 @@ public class DotNetWrapper extends SimpleBuildWrapper {
      * Because the value is set from a list box (so selecting invalid values is not possible), this only ensures that it's filled.
      *
      * @param value The value to check.
+     * @param item  The item being configured.
      *
      * @return The validation result.
      */
     @NonNull
     @POST
-    public FormValidation doCheckSdk(@CheckForNull @QueryParameter String value) {
+    public FormValidation doCheckSdk(@CheckForNull @QueryParameter String value, @NonNull @AncestorInPath Item item) {
+      item.checkPermission(Permission.CONFIGURE);
       return FormValidation.validateRequired(value);
     }
 
     /**
      * Fills a listbox with the available .NET SDKs.
      *
+     * @param item The item being configured.
+     *
      * @return A suitably filled listbox model.
      */
     @NonNull
     @POST
-    public ListBoxModel doFillSdkItems() {
+    public ListBoxModel doFillSdkItems(@NonNull @AncestorInPath Item item) {
+      item.checkPermission(Permission.CONFIGURE);
       final ListBoxModel model = new ListBoxModel();
       DotNetSDK.addSdks(model);
       return model;

--- a/src/main/java/io/jenkins/plugins/dotnet/DotNetWrapper.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/DotNetWrapper.java
@@ -22,6 +22,7 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.verb.POST;
 
 import java.io.IOException;
 import java.util.Map;
@@ -105,7 +106,8 @@ public class DotNetWrapper extends SimpleBuildWrapper {
                     @NonNull TaskListener listener, @NonNull EnvVars initialEnvironment) throws IOException, InterruptedException {
     if (this.sdk == null)
       throw new AbortException(String.format(Messages.DotNetWrapper_NoSDK(), this.sdk));
-    final DotNetSDK sdkInstance = Jenkins.get().getDescriptorByType(DotNetSDK.DescriptorImpl.class).prepareAndValidateInstance(this.sdk, workspace, initialEnvironment, listener);
+    final DotNetSDK sdkInstance = Jenkins.get().getDescriptorByType(DotNetSDK.DescriptorImpl.class)
+      .prepareAndValidateInstance(this.sdk, workspace, initialEnvironment, listener);
     sdkInstance.ensureExecutableExists(launcher);
     { // Update Environment
       final EnvVars modified = new EnvVars();
@@ -133,7 +135,8 @@ public class DotNetWrapper extends SimpleBuildWrapper {
      * @param listener  The listener for the build.
      */
     @Override
-    public void tearDown(@NonNull Run<?, ?> build, @NonNull FilePath workspace, @NonNull Launcher launcher, @NonNull TaskListener listener) {
+    public void tearDown(@NonNull Run<?, ?> build, @NonNull FilePath workspace, @NonNull Launcher launcher,
+                         @NonNull TaskListener listener) {
       DotNetSDK.removeGlobalJson(workspace, listener);
     }
 
@@ -168,8 +171,8 @@ public class DotNetWrapper extends SimpleBuildWrapper {
      *
      * @return The validation result.
      */
-    @SuppressWarnings("unused")
     @NonNull
+    @POST
     public FormValidation doCheckSdk(@CheckForNull @QueryParameter String value) {
       return FormValidation.validateRequired(value);
     }
@@ -179,8 +182,8 @@ public class DotNetWrapper extends SimpleBuildWrapper {
      *
      * @return A suitably filled listbox model.
      */
-    @SuppressWarnings("unused")
     @NonNull
+    @POST
     public ListBoxModel doFillSdkItems() {
       final ListBoxModel model = new ListBoxModel();
       DotNetSDK.addSdks(model);

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/Command.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/Command.java
@@ -243,7 +243,6 @@ public class Command extends Builder implements SimpleBuildStep {
    *                           otherwise.
    */
   @DataBoundSetter
-  @SuppressWarnings("unused")
   public void setSpecificSdkVersion(boolean specificSdkVersion) {
     this.specificSdkVersion = specificSdkVersion;
   }
@@ -275,7 +274,6 @@ public class Command extends Builder implements SimpleBuildStep {
    * @param workDirectory The working directory to use for the command.
    */
   @DataBoundSetter
-  @SuppressWarnings("unused")
   public void setWorkDirectory(@CheckForNull String workDirectory) {
     this.workDirectory = Util.fixEmpty(workDirectory);
   }

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/CommandDescriptor.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/CommandDescriptor.java
@@ -7,6 +7,8 @@ import hudson.Util;
 import hudson.model.AbstractProject;
 import hudson.model.AutoCompletionCandidates;
 import hudson.model.FreeStyleProject;
+import hudson.model.Item;
+import hudson.security.Permission;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.util.FormValidation;
@@ -15,6 +17,7 @@ import io.jenkins.plugins.dotnet.DotNetSDK;
 import io.jenkins.plugins.dotnet.data.Framework;
 import io.jenkins.plugins.dotnet.data.Runtime;
 import org.jenkinsci.plugins.structs.describable.CustomDescribableModel;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.verb.POST;
 
@@ -46,12 +49,17 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
    * Performs auto-completion for a .NET target framework moniker.
    *
    * @param value The (partial) value to perform auto-completion for.
+   * @param item  The item being configured.
    *
    * @return The computed auto-completion candidates.
    */
   @NonNull
   @POST
-  public final AutoCompletionCandidates doAutoCompleteFramework(@CheckForNull @QueryParameter String value) {
+  public final AutoCompletionCandidates doAutoCompleteFramework(@CheckForNull @QueryParameter String value,
+                                                                @CheckForNull @AncestorInPath Item item) {
+    if (item != null) {
+      item.checkPermission(Permission.CONFIGURE);
+    }
     return Framework.getInstance().autoCompleteMoniker(value);
   }
 
@@ -59,12 +67,17 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
    * Performs auto-completion for a list of .NET target framework monikers.
    *
    * @param value The (partial) value to perform auto-completion for.
+   * @param item  The item being configured.
    *
    * @return The computed auto-completion candidates.
    */
   @NonNull
   @POST
-  public final AutoCompletionCandidates doAutoCompleteFrameworksString(@CheckForNull @QueryParameter String value) {
+  public final AutoCompletionCandidates doAutoCompleteFrameworksString(@CheckForNull @QueryParameter String value,
+                                                                       @CheckForNull @AncestorInPath Item item) {
+    if (item != null) {
+      item.checkPermission(Permission.CONFIGURE);
+    }
     return Framework.getInstance().autoCompleteMoniker(value);
   }
 
@@ -72,12 +85,17 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
    * Performs auto-completion for a .NET target runtime identifier.
    *
    * @param value The (partial) value to perform auto-completion for.
+   * @param item  The item being configured.
    *
    * @return The computed auto-completion candidates.
    */
   @NonNull
   @POST
-  public final AutoCompletionCandidates doAutoCompleteRuntime(@CheckForNull @QueryParameter String value) {
+  public final AutoCompletionCandidates doAutoCompleteRuntime(@CheckForNull @QueryParameter String value,
+                                                              @CheckForNull @AncestorInPath Item item) {
+    if (item != null) {
+      item.checkPermission(Permission.CONFIGURE);
+    }
     return Runtime.getInstance().autoCompleteIdentifier(value);
   }
 
@@ -85,12 +103,17 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
    * Performs auto-completion for a list of .NET runtime identifiers.
    *
    * @param value The (partial) value to perform auto-completion for.
+   * @param item  The item being configured.
    *
    * @return The computed auto-completion candidates.
    */
   @NonNull
   @POST
-  public final AutoCompletionCandidates doAutoCompleteRuntimesString(@CheckForNull @QueryParameter String value) {
+  public final AutoCompletionCandidates doAutoCompleteRuntimesString(@CheckForNull @QueryParameter String value,
+                                                                     @CheckForNull @AncestorInPath Item item) {
+    if (item != null) {
+      item.checkPermission(Permission.CONFIGURE);
+    }
     return Runtime.getInstance().autoCompleteIdentifier(value);
   }
 
@@ -98,12 +121,16 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
    * Performs validation on a Java charset name.
    *
    * @param value The value to validate.
+   * @param item  The item being configured.
    *
    * @return The result of the validation.
    */
   @NonNull
   @POST
-  public FormValidation doCheckCharset(@CheckForNull @QueryParameter String value) {
+  public FormValidation doCheckCharset(@CheckForNull @QueryParameter String value, @CheckForNull @AncestorInPath Item item) {
+    if (item != null) {
+      item.checkPermission(Permission.CONFIGURE);
+    }
     final String name = Util.fixEmptyAndTrim(value);
     if (name != null) {
       try {
@@ -120,12 +147,16 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
    * Performs validation on a .NET target framework moniker.
    *
    * @param value The value to validate.
+   * @param item  The item being configured.
    *
    * @return The result of the validation.
    */
   @NonNull
   @POST
-  public FormValidation doCheckFramework(@CheckForNull @QueryParameter String value) {
+  public FormValidation doCheckFramework(@CheckForNull @QueryParameter String value, @CheckForNull @AncestorInPath Item item) {
+    if (item != null) {
+      item.checkPermission(Permission.CONFIGURE);
+    }
     return Framework.getInstance().checkMoniker(value);
   }
 
@@ -133,12 +164,16 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
    * Performs validation on a list of .NET target framework monikers.
    *
    * @param value The value to validate.
+   * @param item  The item being configured.
    *
    * @return The result of the validation.
    */
   @NonNull
   @POST
-  public FormValidation doCheckFrameworksString(@CheckForNull @QueryParameter String value) {
+  public FormValidation doCheckFrameworksString(@CheckForNull @QueryParameter String value, @CheckForNull @AncestorInPath Item item) {
+    if (item != null) {
+      item.checkPermission(Permission.CONFIGURE);
+    }
     return Framework.getInstance().checkMonikers(value);
   }
 
@@ -146,12 +181,16 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
    * Performs validation on a .NET runtime identifier.
    *
    * @param value The value to validate.
+   * @param item  The item being configured.
    *
    * @return The result of the validation.
    */
   @NonNull
   @POST
-  public FormValidation doCheckRuntime(@CheckForNull @QueryParameter String value) {
+  public FormValidation doCheckRuntime(@CheckForNull @QueryParameter String value, @CheckForNull @AncestorInPath Item item) {
+    if (item != null) {
+      item.checkPermission(Permission.CONFIGURE);
+    }
     return Runtime.getInstance().checkIdentifier(value);
   }
 
@@ -159,23 +198,32 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
    * Performs validation on a list of .NET runtime identifiers.
    *
    * @param value The values to validate.
+   * @param item  The item being configured.
    *
    * @return The result of the validation.
    */
   @NonNull
   @POST
-  public FormValidation doCheckRuntimesString(@CheckForNull @QueryParameter String value) {
+  public FormValidation doCheckRuntimesString(@CheckForNull @QueryParameter String value, @CheckForNull @AncestorInPath Item item) {
+    if (item != null) {
+      item.checkPermission(Permission.CONFIGURE);
+    }
     return Runtime.getInstance().checkIdentifiers(value);
   }
 
   /**
    * Fills a listbox with the names of charsets supported by the running version of Java.
    *
+   * @param item The item being configured.
+   *
    * @return A suitably filled listbox model.
    */
   @NonNull
   @POST
-  public final ListBoxModel doFillCharsetItems() {
+  public final ListBoxModel doFillCharsetItems(@CheckForNull @AncestorInPath Item item) {
+    if (item != null) {
+      item.checkPermission(Permission.CONFIGURE);
+    }
     final ListBoxModel model = new ListBoxModel();
     model.add(Messages.Command_SameCharsetAsBuild(), "");
     for (final Charset cs : Charset.availableCharsets().values()) {
@@ -194,11 +242,16 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
   /**
    * Fills a listbox with the names of .NET SDKs that have been defined as global tools.
    *
+   * @param item The item being configured.
+   *
    * @return A suitably filled listbox model.
    */
   @NonNull
   @POST
-  public final ListBoxModel doFillSdkItems() {
+  public final ListBoxModel doFillSdkItems(@CheckForNull @AncestorInPath Item item) {
+    if (item != null) {
+      item.checkPermission(Permission.CONFIGURE);
+    }
     final ListBoxModel model = new ListBoxModel();
     model.add(Messages.Command_DefaultSDK(), "");
     DotNetSDK.addSdks(model);
@@ -208,11 +261,16 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
   /**
    * Fills a listbox with the possible values for the .NET CLI "verbosity" option.
    *
+   * @param item The item being configured.
+   *
    * @return A suitably filled listbox model.
    */
   @NonNull
   @POST
-  public final ListBoxModel doFillVerbosityItems() {
+  public final ListBoxModel doFillVerbosityItems(@CheckForNull @AncestorInPath Item item) {
+    if (item != null) {
+      item.checkPermission(Permission.CONFIGURE);
+    }
     final ListBoxModel model = new ListBoxModel();
     model.add(Messages.Command_Verbosity_Default(), "");
     model.add(Messages.Command_Verbosity_Quiet(), "q");

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/CommandDescriptor.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/CommandDescriptor.java
@@ -16,6 +16,7 @@ import io.jenkins.plugins.dotnet.data.Framework;
 import io.jenkins.plugins.dotnet.data.Runtime;
 import org.jenkinsci.plugins.structs.describable.CustomDescribableModel;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.verb.POST;
 
 import java.nio.charset.Charset;
 import java.util.Set;
@@ -48,8 +49,8 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
    *
    * @return The computed auto-completion candidates.
    */
-  @SuppressWarnings("unused")
   @NonNull
+  @POST
   public final AutoCompletionCandidates doAutoCompleteFramework(@CheckForNull @QueryParameter String value) {
     return Framework.getInstance().autoCompleteMoniker(value);
   }
@@ -61,8 +62,8 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
    *
    * @return The computed auto-completion candidates.
    */
-  @SuppressWarnings("unused")
   @NonNull
+  @POST
   public final AutoCompletionCandidates doAutoCompleteFrameworksString(@CheckForNull @QueryParameter String value) {
     return Framework.getInstance().autoCompleteMoniker(value);
   }
@@ -74,8 +75,8 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
    *
    * @return The computed auto-completion candidates.
    */
-  @SuppressWarnings("unused")
   @NonNull
+  @POST
   public final AutoCompletionCandidates doAutoCompleteRuntime(@CheckForNull @QueryParameter String value) {
     return Runtime.getInstance().autoCompleteIdentifier(value);
   }
@@ -87,8 +88,8 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
    *
    * @return The computed auto-completion candidates.
    */
-  @SuppressWarnings("unused")
   @NonNull
+  @POST
   public final AutoCompletionCandidates doAutoCompleteRuntimesString(@CheckForNull @QueryParameter String value) {
     return Runtime.getInstance().autoCompleteIdentifier(value);
   }
@@ -100,8 +101,8 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
    *
    * @return The result of the validation.
    */
-  @SuppressWarnings("unused")
   @NonNull
+  @POST
   public FormValidation doCheckCharset(@CheckForNull @QueryParameter String value) {
     final String name = Util.fixEmptyAndTrim(value);
     if (name != null) {
@@ -122,8 +123,8 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
    *
    * @return The result of the validation.
    */
-  @SuppressWarnings("unused")
   @NonNull
+  @POST
   public FormValidation doCheckFramework(@CheckForNull @QueryParameter String value) {
     return Framework.getInstance().checkMoniker(value);
   }
@@ -135,8 +136,8 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
    *
    * @return The result of the validation.
    */
-  @SuppressWarnings("unused")
   @NonNull
+  @POST
   public FormValidation doCheckFrameworksString(@CheckForNull @QueryParameter String value) {
     return Framework.getInstance().checkMonikers(value);
   }
@@ -148,8 +149,8 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
    *
    * @return The result of the validation.
    */
-  @SuppressWarnings("unused")
   @NonNull
+  @POST
   public FormValidation doCheckRuntime(@CheckForNull @QueryParameter String value) {
     return Runtime.getInstance().checkIdentifier(value);
   }
@@ -161,8 +162,8 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
    *
    * @return The result of the validation.
    */
-  @SuppressWarnings("unused")
   @NonNull
+  @POST
   public FormValidation doCheckRuntimesString(@CheckForNull @QueryParameter String value) {
     return Runtime.getInstance().checkIdentifiers(value);
   }
@@ -172,8 +173,8 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
    *
    * @return A suitably filled listbox model.
    */
-  @SuppressWarnings("unused")
   @NonNull
+  @POST
   public final ListBoxModel doFillCharsetItems() {
     final ListBoxModel model = new ListBoxModel();
     model.add(Messages.Command_SameCharsetAsBuild(), "");
@@ -195,8 +196,8 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
    *
    * @return A suitably filled listbox model.
    */
-  @SuppressWarnings("unused")
   @NonNull
+  @POST
   public final ListBoxModel doFillSdkItems() {
     final ListBoxModel model = new ListBoxModel();
     model.add(Messages.Command_DefaultSDK(), "");
@@ -209,8 +210,8 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
    *
    * @return A suitably filled listbox model.
    */
-  @SuppressWarnings("unused")
   @NonNull
+  @POST
   public final ListBoxModel doFillVerbosityItems() {
     final ListBoxModel model = new ListBoxModel();
     model.add(Messages.Command_Verbosity_Default(), "");

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/FreeStyleCommandConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/FreeStyleCommandConfiguration.java
@@ -20,6 +20,7 @@ import jenkins.tools.ToolConfigurationCategory;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.verb.POST;
 
 import java.io.Serializable;
 
@@ -48,6 +49,7 @@ public class FreeStyleCommandConfiguration extends GlobalConfiguration implement
   private boolean buildAllowed = true;
 
   @NonNull
+  @POST
   public FormValidation doCheckBuildAllowed(@QueryParameter boolean buildAllowed) {
     return FreeStyleCommandConfiguration.ensureNotInUseWhenDisallowed(buildAllowed, Build.class);
   }
@@ -75,6 +77,7 @@ public class FreeStyleCommandConfiguration extends GlobalConfiguration implement
   private boolean cleanAllowed = true;
 
   @NonNull
+  @POST
   public FormValidation doCheckCleanAllowed(@QueryParameter boolean cleanAllowed) {
     return FreeStyleCommandConfiguration.ensureNotInUseWhenDisallowed(cleanAllowed, Clean.class);
   }
@@ -102,6 +105,7 @@ public class FreeStyleCommandConfiguration extends GlobalConfiguration implement
   private boolean listPackageAllowed = true;
 
   @NonNull
+  @POST
   public FormValidation doCheckListPackageAllowed(@QueryParameter boolean listPackageAllowed) {
     return FreeStyleCommandConfiguration.ensureNotInUseWhenDisallowed(listPackageAllowed, ListPackage.class);
   }
@@ -129,6 +133,7 @@ public class FreeStyleCommandConfiguration extends GlobalConfiguration implement
   private boolean nuGetDeleteAllowed = true;
 
   @NonNull
+  @POST
   public FormValidation doCheckNuGetDeleteAllowed(@QueryParameter boolean nuGetDeleteAllowed) {
     return FreeStyleCommandConfiguration.ensureNotInUseWhenDisallowed(nuGetDeleteAllowed, Delete.class);
   }
@@ -156,6 +161,7 @@ public class FreeStyleCommandConfiguration extends GlobalConfiguration implement
   private boolean nuGetLocalsAllowed = true;
 
   @NonNull
+  @POST
   public FormValidation doCheckNuGetLocalsAllowed(@QueryParameter boolean nuGetLocalsAllowed) {
     return FreeStyleCommandConfiguration.ensureNotInUseWhenDisallowed(nuGetLocalsAllowed, Locals.class);
   }
@@ -183,6 +189,7 @@ public class FreeStyleCommandConfiguration extends GlobalConfiguration implement
   private boolean nuGetPushAllowed = true;
 
   @NonNull
+  @POST
   public FormValidation doCheckNuGetPushAllowed(@QueryParameter boolean nuGetPushAllowed) {
     return FreeStyleCommandConfiguration.ensureNotInUseWhenDisallowed(nuGetPushAllowed, Push.class);
   }
@@ -210,6 +217,7 @@ public class FreeStyleCommandConfiguration extends GlobalConfiguration implement
   private boolean packAllowed = true;
 
   @NonNull
+  @POST
   public FormValidation doCheckPackAllowed(@QueryParameter boolean packAllowed) {
     return FreeStyleCommandConfiguration.ensureNotInUseWhenDisallowed(packAllowed, Pack.class);
   }
@@ -237,6 +245,7 @@ public class FreeStyleCommandConfiguration extends GlobalConfiguration implement
   private boolean publishAllowed = true;
 
   @NonNull
+  @POST
   public FormValidation doCheckPublishAllowed(@QueryParameter boolean publishAllowed) {
     return FreeStyleCommandConfiguration.ensureNotInUseWhenDisallowed(publishAllowed, Publish.class);
   }
@@ -264,6 +273,7 @@ public class FreeStyleCommandConfiguration extends GlobalConfiguration implement
   private boolean restoreAllowed = true;
 
   @NonNull
+  @POST
   public FormValidation doCheckRestoreAllowed(@QueryParameter boolean restoreAllowed) {
     return FreeStyleCommandConfiguration.ensureNotInUseWhenDisallowed(restoreAllowed, Restore.class);
   }
@@ -291,6 +301,7 @@ public class FreeStyleCommandConfiguration extends GlobalConfiguration implement
   private boolean testAllowed = true;
 
   @NonNull
+  @POST
   public FormValidation doCheckTestAllowed(@QueryParameter boolean testAllowed) {
     return FreeStyleCommandConfiguration.ensureNotInUseWhenDisallowed(testAllowed, Test.class);
   }
@@ -318,6 +329,7 @@ public class FreeStyleCommandConfiguration extends GlobalConfiguration implement
   private boolean toolRestoreAllowed = true;
 
   @NonNull
+  @POST
   public FormValidation doCheckToolRestoreAllowed(@QueryParameter boolean toolRestoreAllowed) {
     final Class<? extends Command> toolRestore = io.jenkins.plugins.dotnet.commands.tool.Restore.class;
     return FreeStyleCommandConfiguration.ensureNotInUseWhenDisallowed(toolRestoreAllowed, toolRestore);

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/FreeStyleCommandConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/FreeStyleCommandConfiguration.java
@@ -357,11 +357,12 @@ public class FreeStyleCommandConfiguration extends GlobalConfiguration implement
 
   @NonNull
   private static FormValidation ensureNotInUseWhenDisallowed(boolean allowed, @NonNull Class<? extends Command> command) {
-    Jenkins.get().checkPermission(Jenkins.ADMINISTER);
     if (allowed) {
       return FormValidation.ok();
     }
-    final int uses = Jenkins.get().getAllItems(FreeStyleProject.class,
+    final Jenkins jenkins = Jenkins.get();
+    jenkins.checkPermission(Jenkins.MANAGE);
+    final int uses = jenkins.getAllItems(FreeStyleProject.class,
       project -> FreeStyleCommandConfiguration.includesCommand(project, command)).size();
     if (uses == 0) {
       return FormValidation.ok();

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/FreeStyleCommandConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/FreeStyleCommandConfiguration.java
@@ -357,6 +357,7 @@ public class FreeStyleCommandConfiguration extends GlobalConfiguration implement
 
   @NonNull
   private static FormValidation ensureNotInUseWhenDisallowed(boolean allowed, @NonNull Class<? extends Command> command) {
+    Jenkins.get().checkPermission(Jenkins.ADMINISTER);
     if (allowed) {
       return FormValidation.ok();
     }

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/ListPackage.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/ListPackage.java
@@ -4,10 +4,13 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
+import hudson.model.Item;
+import hudson.security.Permission;
 import hudson.util.FormValidation;
 import io.jenkins.plugins.dotnet.DotNetUtils;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -465,13 +468,17 @@ public final class ListPackage extends Command {
      * @param value      The specified configuration file name.
      * @param deprecated Flag indicating whether deprecated packages should be listed.
      * @param outdated   Flag indicating whether outdated packages should be listed.
+     * @param item       The item being configured.
      *
      * @return The validation result.
      */
     @NonNull
     @POST
     public FormValidation doCheckConfig(@CheckForNull @QueryParameter String value, @QueryParameter boolean deprecated,
-                                        @QueryParameter boolean outdated) {
+                                        @QueryParameter boolean outdated, @CheckForNull @AncestorInPath Item item) {
+      if (item != null) {
+        item.checkPermission(Permission.CONFIGURE);
+      }
       if (Util.fixEmptyAndTrim(value) != null && !deprecated && !outdated) {
         return FormValidation.warning(Messages.ListPackage_OnlyForPackageUpdateSearch());
       }
@@ -483,12 +490,17 @@ public final class ListPackage extends Command {
      *
      * @param deprecated Flag indicating whether deprecated packages should be listed.
      * @param outdated   Flag indicating whether outdated packages should be listed.
+     * @param item       The item being configured.
      *
      * @return The validation result.
      */
     @NonNull
     @POST
-    public FormValidation doCheckDeprecated(@QueryParameter boolean deprecated, @QueryParameter boolean outdated) {
+    public FormValidation doCheckDeprecated(@QueryParameter boolean deprecated, @QueryParameter boolean outdated,
+                                            @CheckForNull @AncestorInPath Item item) {
+      if (item != null) {
+        item.checkPermission(Permission.CONFIGURE);
+      }
       if (deprecated && outdated) {
         return FormValidation.error(Messages.ListPackage_EitherDeprecatedOrOutdated());
       }
@@ -501,13 +513,17 @@ public final class ListPackage extends Command {
      * @param value      Flag indicating whether the minor version is the highest version that is allowed to change.
      * @param deprecated Flag indicating whether deprecated packages should be listed.
      * @param outdated   Flag indicating whether outdated packages should be listed.
+     * @param item       The item being configured.
      *
      * @return The validation result.
      */
     @NonNull
     @POST
     public FormValidation doCheckHighestMinor(@QueryParameter boolean value, @QueryParameter boolean deprecated,
-                                              @QueryParameter boolean outdated) {
+                                              @QueryParameter boolean outdated, @CheckForNull @AncestorInPath Item item) {
+      if (item != null) {
+        item.checkPermission(Permission.CONFIGURE);
+      }
       if (value && !deprecated && !outdated) {
         return FormValidation.warning(Messages.ListPackage_OnlyForPackageUpdateSearch());
       }
@@ -520,13 +536,17 @@ public final class ListPackage extends Command {
      * @param value      Flag indicating whether the patch version is the highest version that is allowed to change.
      * @param deprecated Flag indicating whether deprecated packages should be listed.
      * @param outdated   Flag indicating whether outdated packages should be listed.
+     * @param item       The item being configured.
      *
      * @return The validation result.
      */
     @NonNull
     @POST
     public FormValidation doCheckHighestPatch(@QueryParameter boolean value, @QueryParameter boolean deprecated,
-                                              @QueryParameter boolean outdated) {
+                                              @QueryParameter boolean outdated, @CheckForNull @AncestorInPath Item item) {
+      if (item != null) {
+        item.checkPermission(Permission.CONFIGURE);
+      }
       if (value && !deprecated && !outdated) {
         return FormValidation.warning(Messages.ListPackage_OnlyForPackageUpdateSearch());
       }
@@ -539,13 +559,17 @@ public final class ListPackage extends Command {
      * @param value      Flag indicating whether prerelease package versions should be listed.
      * @param deprecated Flag indicating whether deprecated packages should be listed.
      * @param outdated   Flag indicating whether outdated packages should be listed.
+     * @param item       The item being configured.
      *
      * @return The validation result.
      */
     @NonNull
     @POST
     public FormValidation doCheckIncludePrerelease(@QueryParameter boolean value, @QueryParameter boolean deprecated,
-                                                   @QueryParameter boolean outdated) {
+                                                   @QueryParameter boolean outdated, @CheckForNull @AncestorInPath Item item) {
+      if (item != null) {
+        item.checkPermission(Permission.CONFIGURE);
+      }
       if (value && !deprecated && !outdated) {
         return FormValidation.warning(Messages.ListPackage_OnlyForPackageUpdateSearch());
       }
@@ -557,12 +581,17 @@ public final class ListPackage extends Command {
      *
      * @param deprecated Flag indicating whether deprecated packages should be listed.
      * @param outdated   Flag indicating whether outdated packages should be listed.
+     * @param item       The item being configured.
      *
      * @return The validation result.
      */
     @NonNull
     @POST
-    public FormValidation doCheckOutdated(@QueryParameter boolean deprecated, @QueryParameter boolean outdated) {
+    public FormValidation doCheckOutdated(@QueryParameter boolean deprecated, @QueryParameter boolean outdated,
+                                          @CheckForNull @AncestorInPath Item item) {
+      if (item != null) {
+        item.checkPermission(Permission.CONFIGURE);
+      }
       if (deprecated && outdated) {
         return FormValidation.error(Messages.ListPackage_EitherDeprecatedOrOutdated());
       }
@@ -575,13 +604,17 @@ public final class ListPackage extends Command {
      * @param value      The specified package sources.
      * @param deprecated Flag indicating whether deprecated packages should be listed.
      * @param outdated   Flag indicating whether outdated packages should be listed.
+     * @param item       The item being configured.
      *
      * @return The validation result.
      */
     @NonNull
     @POST
     public FormValidation doCheckSourcesString(@CheckForNull @QueryParameter String value, @QueryParameter boolean deprecated,
-                                               @QueryParameter boolean outdated) {
+                                               @QueryParameter boolean outdated, @CheckForNull @AncestorInPath Item item) {
+      if (item != null) {
+        item.checkPermission(Permission.CONFIGURE);
+      }
       if (Util.fixEmptyAndTrim(value) != null && !deprecated && !outdated) {
         return FormValidation.warning(Messages.ListPackage_OnlyForPackageUpdateSearch());
       }

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/ListPackage.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/ListPackage.java
@@ -468,8 +468,8 @@ public final class ListPackage extends Command {
      *
      * @return The validation result.
      */
-    @SuppressWarnings("unused")
     @NonNull
+    @POST
     public FormValidation doCheckConfig(@CheckForNull @QueryParameter String value, @QueryParameter boolean deprecated,
                                         @QueryParameter boolean outdated) {
       if (Util.fixEmptyAndTrim(value) != null && !deprecated && !outdated) {
@@ -486,8 +486,8 @@ public final class ListPackage extends Command {
      *
      * @return The validation result.
      */
-    @SuppressWarnings("unused")
     @NonNull
+    @POST
     public FormValidation doCheckDeprecated(@QueryParameter boolean deprecated, @QueryParameter boolean outdated) {
       if (deprecated && outdated) {
         return FormValidation.error(Messages.ListPackage_EitherDeprecatedOrOutdated());
@@ -504,8 +504,8 @@ public final class ListPackage extends Command {
      *
      * @return The validation result.
      */
-    @SuppressWarnings("unused")
     @NonNull
+    @POST
     public FormValidation doCheckHighestMinor(@QueryParameter boolean value, @QueryParameter boolean deprecated,
                                               @QueryParameter boolean outdated) {
       if (value && !deprecated && !outdated) {
@@ -523,8 +523,8 @@ public final class ListPackage extends Command {
      *
      * @return The validation result.
      */
-    @SuppressWarnings("unused")
     @NonNull
+    @POST
     public FormValidation doCheckHighestPatch(@QueryParameter boolean value, @QueryParameter boolean deprecated,
                                               @QueryParameter boolean outdated) {
       if (value && !deprecated && !outdated) {
@@ -542,8 +542,8 @@ public final class ListPackage extends Command {
      *
      * @return The validation result.
      */
-    @SuppressWarnings("unused")
     @NonNull
+    @POST
     public FormValidation doCheckIncludePrerelease(@QueryParameter boolean value, @QueryParameter boolean deprecated,
                                                    @QueryParameter boolean outdated) {
       if (value && !deprecated && !outdated) {
@@ -560,8 +560,8 @@ public final class ListPackage extends Command {
      *
      * @return The validation result.
      */
-    @SuppressWarnings("unused")
     @NonNull
+    @POST
     public FormValidation doCheckOutdated(@QueryParameter boolean deprecated, @QueryParameter boolean outdated) {
       if (deprecated && outdated) {
         return FormValidation.error(Messages.ListPackage_EitherDeprecatedOrOutdated());
@@ -578,8 +578,8 @@ public final class ListPackage extends Command {
      *
      * @return The validation result.
      */
-    @SuppressWarnings("unused")
     @NonNull
+    @POST
     public FormValidation doCheckSourcesString(@CheckForNull @QueryParameter String value, @QueryParameter boolean deprecated,
                                                @QueryParameter boolean outdated) {
       if (Util.fixEmptyAndTrim(value) != null && !deprecated && !outdated) {

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/MSBuildCommandDescriptor.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/MSBuildCommandDescriptor.java
@@ -8,6 +8,7 @@ import io.jenkins.plugins.dotnet.commands.CommandDescriptor;
 import io.jenkins.plugins.dotnet.commands.Messages;
 import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.verb.POST;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -40,8 +41,8 @@ public abstract class MSBuildCommandDescriptor extends CommandDescriptor {
    *
    * @return The result of the validation.
    */
-  @SuppressWarnings("unused")
   @NonNull
+  @POST
   public FormValidation doCheckPropertiesString(@QueryParameter String value) {
     value = Util.fixEmptyAndTrim(value);
     if (value != null) {
@@ -60,7 +61,8 @@ public abstract class MSBuildCommandDescriptor extends CommandDescriptor {
    *
    * @return A suitable filled combobox model.
    */
-  @SuppressWarnings("unused")
+  @NonNull
+  @POST
   public final ComboBoxModel doFillConfigurationItems() {
     final ComboBoxModel model = new ComboBoxModel();
     // Note: not localized

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/MSBuildCommandDescriptor.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/MSBuildCommandDescriptor.java
@@ -1,12 +1,16 @@
 package io.jenkins.plugins.dotnet.commands.msbuild;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Util;
+import hudson.model.Item;
+import hudson.security.Permission;
 import hudson.util.ComboBoxModel;
 import hudson.util.FormValidation;
 import io.jenkins.plugins.dotnet.commands.CommandDescriptor;
 import io.jenkins.plugins.dotnet.commands.Messages;
 import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.verb.POST;
 
@@ -38,12 +42,16 @@ public abstract class MSBuildCommandDescriptor extends CommandDescriptor {
    * Performs validation on a set of MSBuild properties.
    *
    * @param value The value to validate.
+   * @param item  The item being configured.
    *
    * @return The result of the validation.
    */
   @NonNull
   @POST
-  public FormValidation doCheckPropertiesString(@QueryParameter String value) {
+  public FormValidation doCheckPropertiesString(@QueryParameter String value, @CheckForNull @AncestorInPath Item item) {
+    if (item != null) {
+      item.checkPermission(Permission.CONFIGURE);
+    }
     value = Util.fixEmptyAndTrim(value);
     if (value != null) {
       try {
@@ -59,11 +67,16 @@ public abstract class MSBuildCommandDescriptor extends CommandDescriptor {
   /**
    * Fills a combobox with standard MSBuild configuration names.
    *
+   * @param item The item being configured.
+   *
    * @return A suitable filled combobox model.
    */
   @NonNull
   @POST
-  public final ComboBoxModel doFillConfigurationItems() {
+  public final ComboBoxModel doFillConfigurationItems(@CheckForNull @AncestorInPath Item item) {
+    if (item != null) {
+      item.checkPermission(Permission.CONFIGURE);
+    }
     final ComboBoxModel model = new ComboBoxModel();
     // Note: not localized
     model.add("Debug");

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Publish.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Publish.java
@@ -4,6 +4,8 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
+import hudson.model.Item;
+import hudson.security.Permission;
 import hudson.util.ListBoxModel;
 import io.jenkins.plugins.dotnet.DotNetUtils;
 import io.jenkins.plugins.dotnet.commands.DotNetArguments;
@@ -11,6 +13,7 @@ import io.jenkins.plugins.dotnet.commands.FreeStyleCommandConfiguration;
 import io.jenkins.plugins.dotnet.commands.Messages;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.verb.POST;
@@ -335,11 +338,16 @@ public final class Publish extends MSBuildCommand {
     /**
      * Fills a listbox with the possible values for the "self-containing" setting.
      *
+     * @param item The item being configured.
+     *
      * @return A suitably filled listbox model.
      */
     @NonNull
     @POST
-    public ListBoxModel doFillSelfContainedItems() {
+    public ListBoxModel doFillSelfContainedItems(@CheckForNull @AncestorInPath Item item) {
+      if (item != null) {
+        item.checkPermission(Permission.CONFIGURE);
+      }
       final ListBoxModel model = new ListBoxModel();
       model.add(Messages.MSBuild_Publish_ProjectDefault(), null);
       model.add(Messages.MSBuild_Publish_Yes(), "true");

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Publish.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Publish.java
@@ -13,6 +13,7 @@ import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.verb.POST;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -336,8 +337,8 @@ public final class Publish extends MSBuildCommand {
      *
      * @return A suitably filled listbox model.
      */
-    @SuppressWarnings("unused")
     @NonNull
+    @POST
     public ListBoxModel doFillSelfContainedItems() {
       final ListBoxModel model = new ListBoxModel();
       model.add(Messages.MSBuild_Publish_ProjectDefault(), null);

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Test.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Test.java
@@ -4,6 +4,8 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
+import hudson.model.Item;
+import hudson.security.Permission;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import io.jenkins.plugins.dotnet.DotNetUtils;
@@ -12,6 +14,7 @@ import io.jenkins.plugins.dotnet.commands.FreeStyleCommandConfiguration;
 import io.jenkins.plugins.dotnet.commands.Messages;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -593,12 +596,17 @@ public final class Test extends MSBuildCommand {
      * Performs (basic) validation on a test timeout.
      *
      * @param value The timeout to validate.
+     * @param item  The item being configured.
      *
      * @return The validation result.
      */
     @NonNull
     @POST
-    public FormValidation doCheckBlameHangTimeout(@CheckForNull @QueryParameter Integer value) {
+    public FormValidation doCheckBlameHangTimeout(@CheckForNull @QueryParameter Integer value,
+                                                  @CheckForNull @AncestorInPath Item item) {
+      if (item != null) {
+        item.checkPermission(Permission.CONFIGURE);
+      }
       if (value == null) {
         return FormValidation.ok();
       }
@@ -629,12 +637,17 @@ public final class Test extends MSBuildCommand {
      * Performs (basic) validation on a set of run settings.
      *
      * @param value The run settings to validate.
+     * @param item  The item being configured.
      *
      * @return The validation result.
      */
     @NonNull
     @POST
-    public FormValidation doCheckRunSettingsString(@CheckForNull @QueryParameter String value) {
+    public FormValidation doCheckRunSettingsString(@CheckForNull @QueryParameter String value,
+                                                   @CheckForNull @AncestorInPath Item item) {
+      if (item != null) {
+        item.checkPermission(Permission.CONFIGURE);
+      }
       value = Util.fixEmptyAndTrim(value);
       if (value != null) {
         try {
@@ -650,11 +663,16 @@ public final class Test extends MSBuildCommand {
     /**
      * Fills a listbox with the possible values for the dump types supported by {@code --blame-crash-dump-type}.
      *
+     * @param item The item being configured.
+     *
      * @return A suitably filled listbox model.
      */
     @NonNull
     @POST
-    public final ListBoxModel doFillBlameCrashDumpTypeItems() {
+    public ListBoxModel doFillBlameCrashDumpTypeItems(@CheckForNull @AncestorInPath Item item) {
+      if (item != null) {
+        item.checkPermission(Permission.CONFIGURE);
+      }
       final ListBoxModel model = new ListBoxModel();
       model.add("");
       model.add("mini");
@@ -665,11 +683,16 @@ public final class Test extends MSBuildCommand {
     /**
      * Fills a listbox with the possible values for the dump types supported by {@code --blame-hang-dump-type}.
      *
+     * @param item The item being configured.
+     *
      * @return A suitably filled listbox model.
      */
     @NonNull
     @POST
-    public final ListBoxModel doFillBlameHangDumpTypeItems() {
+    public ListBoxModel doFillBlameHangDumpTypeItems(@CheckForNull @AncestorInPath Item item) {
+      if (item != null) {
+        item.checkPermission(Permission.CONFIGURE);
+      }
       final ListBoxModel model = new ListBoxModel();
       model.add("");
       model.add("none");

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Test.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Test.java
@@ -15,6 +15,7 @@ import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.verb.POST;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -595,8 +596,8 @@ public final class Test extends MSBuildCommand {
      *
      * @return The validation result.
      */
-    @SuppressWarnings("unused")
     @NonNull
+    @POST
     public FormValidation doCheckBlameHangTimeout(@CheckForNull @QueryParameter Integer value) {
       if (value == null) {
         return FormValidation.ok();
@@ -631,8 +632,8 @@ public final class Test extends MSBuildCommand {
      *
      * @return The validation result.
      */
-    @SuppressWarnings("unused")
     @NonNull
+    @POST
     public FormValidation doCheckRunSettingsString(@CheckForNull @QueryParameter String value) {
       value = Util.fixEmptyAndTrim(value);
       if (value != null) {
@@ -651,8 +652,8 @@ public final class Test extends MSBuildCommand {
      *
      * @return A suitably filled listbox model.
      */
-    @SuppressWarnings("unused")
     @NonNull
+    @POST
     public final ListBoxModel doFillBlameCrashDumpTypeItems() {
       final ListBoxModel model = new ListBoxModel();
       model.add("");
@@ -666,8 +667,8 @@ public final class Test extends MSBuildCommand {
      *
      * @return A suitably filled listbox model.
      */
-    @SuppressWarnings("unused")
     @NonNull
+    @POST
     public final ListBoxModel doFillBlameHangDumpTypeItems() {
       final ListBoxModel model = new ListBoxModel();
       model.add("");

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/nuget/Delete.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/nuget/Delete.java
@@ -17,6 +17,7 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.verb.POST;
 
 /** A build step to run "{@code dotnet nuget delete}", deleting or unlisting a specific version of a package from a server. */
 public final class Delete extends DeleteOrPush {
@@ -81,7 +82,8 @@ public final class Delete extends DeleteOrPush {
       this.load();
     }
 
-    @SuppressWarnings("unused")
+    @NonNull
+    @POST
     public FormValidation doCheckPackageName(@QueryParameter String value) {
       value = Util.fixEmptyAndTrim(value);
       // TODO: Maybe do some basic semantic version validation?
@@ -91,7 +93,8 @@ public final class Delete extends DeleteOrPush {
       return FormValidation.ok();
     }
 
-    @SuppressWarnings("unused")
+    @NonNull
+    @POST
     public FormValidation doCheckPackageVersion(@QueryParameter String value, @QueryParameter String packageName) {
       value = Util.fixEmptyAndTrim(value);
       // TODO: Maybe do some basic semantic version validation?
@@ -108,8 +111,8 @@ public final class Delete extends DeleteOrPush {
       return FormValidation.ok();
     }
 
-    @SuppressWarnings("unused")
     @NonNull
+    @POST
     public ListBoxModel doFillApiKeyIdItems(@CheckForNull @AncestorInPath Jenkins context) {
       return DotNetUtils.getStringCredentialsList(context, true);
     }

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/nuget/Locals.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/nuget/Locals.java
@@ -1,13 +1,17 @@
 package io.jenkins.plugins.dotnet.commands.nuget;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.AbortException;
 import hudson.Extension;
+import hudson.model.Item;
+import hudson.security.Permission;
 import hudson.util.ListBoxModel;
-import io.jenkins.plugins.dotnet.commands.FreeStyleCommandConfiguration;
 import io.jenkins.plugins.dotnet.commands.DotNetArguments;
+import io.jenkins.plugins.dotnet.commands.FreeStyleCommandConfiguration;
 import io.jenkins.plugins.dotnet.commands.Messages;
 import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.verb.POST;
@@ -98,9 +102,19 @@ public final class Locals extends NuGetCommand {
       this.load();
     }
 
+    /**
+     * Fills a listbox with the possible NuGet cache locations.
+     *
+     * @param item The item being configured.
+     *
+     * @return A suitably filled listbox model.
+     */
     @NonNull
     @POST
-    public ListBoxModel doFillCacheLocationItems() {
+    public ListBoxModel doFillCacheLocationItems(@CheckForNull @AncestorInPath Item item) {
+      if (item != null) {
+        item.checkPermission(Permission.CONFIGURE);
+      }
       final ListBoxModel model = new ListBoxModel();
       model.add(Messages.NuGet_Locals_Location_All(), Locals.LOCATION_ALL);
       model.add(Messages.NuGet_Locals_Location_GlobalPackages(), Locals.LOCATION_GLOBAL_PACKAGES);
@@ -109,9 +123,19 @@ public final class Locals extends NuGetCommand {
       return model;
     }
 
+    /**
+     * Fills a listbox with the possible operations that can be performed on NuGet cache locations.
+     *
+     * @param item The item being configured.
+     *
+     * @return A suitably filled listbox model.
+     */
     @NonNull
     @POST
-    public ListBoxModel doFillOperationItems() {
+    public ListBoxModel doFillOperationItems(@CheckForNull @AncestorInPath Item item) {
+      if (item != null) {
+        item.checkPermission(Permission.CONFIGURE);
+      }
       final ListBoxModel model = new ListBoxModel();
       model.add(Messages.NuGet_Locals_Operation_Clear(), Locals.OPERATION_CLEAR);
       model.add(Messages.NuGet_Locals_Operation_List(), Locals.OPERATION_LIST);

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/nuget/Locals.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/nuget/Locals.java
@@ -10,6 +10,7 @@ import io.jenkins.plugins.dotnet.commands.Messages;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.verb.POST;
 
 /** A build step to run "{@code dotnet nuget locals}", listing or clearing one or more local package stores. */
 public final class Locals extends NuGetCommand {
@@ -97,8 +98,8 @@ public final class Locals extends NuGetCommand {
       this.load();
     }
 
-    @SuppressWarnings("unused")
     @NonNull
+    @POST
     public ListBoxModel doFillCacheLocationItems() {
       final ListBoxModel model = new ListBoxModel();
       model.add(Messages.NuGet_Locals_Location_All(), Locals.LOCATION_ALL);
@@ -108,8 +109,8 @@ public final class Locals extends NuGetCommand {
       return model;
     }
 
-    @SuppressWarnings("unused")
     @NonNull
+    @POST
     public ListBoxModel doFillOperationItems() {
       final ListBoxModel model = new ListBoxModel();
       model.add(Messages.NuGet_Locals_Operation_Clear(), Locals.OPERATION_CLEAR);

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/nuget/Push.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/nuget/Push.java
@@ -5,12 +5,13 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.AbortException;
 import hudson.Extension;
 import hudson.Util;
+import hudson.model.Item;
+import hudson.security.Permission;
 import hudson.util.ListBoxModel;
 import io.jenkins.plugins.dotnet.DotNetUtils;
-import io.jenkins.plugins.dotnet.commands.FreeStyleCommandConfiguration;
 import io.jenkins.plugins.dotnet.commands.DotNetArguments;
+import io.jenkins.plugins.dotnet.commands.FreeStyleCommandConfiguration;
 import io.jenkins.plugins.dotnet.commands.Messages;
-import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -171,16 +172,36 @@ public final class Push extends DeleteOrPush {
       this.load();
     }
 
+    /**
+     * Fills a listbox with all possible API keys (string credentials) defined in the system.
+     *
+     * @param item The item being configured.
+     *
+     * @return A suitably filled listbox model.
+     */
     @NonNull
     @POST
-    public ListBoxModel doFillApiKeyIdItems(@CheckForNull @AncestorInPath Jenkins context) {
-      return DotNetUtils.getStringCredentialsList(context, true);
+    public ListBoxModel doFillApiKeyIdItems(@CheckForNull @AncestorInPath Item item) {
+      if (item != null) {
+        item.checkPermission(Permission.CONFIGURE);
+      }
+      return DotNetUtils.getStringCredentialsList(true);
     }
 
+    /**
+     * Fills a listbox with all possible API keys (string credentials) defined in the system.
+     *
+     * @param item The item being configured.
+     *
+     * @return A suitably filled listbox model.
+     */
     @NonNull
     @POST
-    public ListBoxModel doFillSymbolApiKeyIdItems(@CheckForNull @AncestorInPath Jenkins context) {
-      return DotNetUtils.getStringCredentialsList(context, true);
+    public ListBoxModel doFillSymbolApiKeyIdItems(@CheckForNull @AncestorInPath Item item) {
+      if (item != null) {
+        item.checkPermission(Permission.CONFIGURE);
+      }
+      return DotNetUtils.getStringCredentialsList(true);
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/nuget/Push.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/nuget/Push.java
@@ -15,6 +15,7 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.verb.POST;
 
 /** A build step to run "{@code dotnet nuget push}", pushing a package to a server and publishing it. */
 public final class Push extends DeleteOrPush {
@@ -170,14 +171,14 @@ public final class Push extends DeleteOrPush {
       this.load();
     }
 
-    @SuppressWarnings("unused")
     @NonNull
+    @POST
     public ListBoxModel doFillApiKeyIdItems(@CheckForNull @AncestorInPath Jenkins context) {
       return DotNetUtils.getStringCredentialsList(context, true);
     }
 
-    @SuppressWarnings("unused")
     @NonNull
+    @POST
     public ListBoxModel doFillSymbolApiKeyIdItems(@CheckForNull @AncestorInPath Jenkins context) {
       return DotNetUtils.getStringCredentialsList(context, true);
     }


### PR DESCRIPTION
The Jenkins security scan reports a bunch of issues, mainly:
- Stapler method (`doXXX`) without `@POST` or `@RequirePOST`
- Stapler method (`doXXX`) without permission check

While these are mostly false positives, they're also easy enough to just fix in the code.
