### PR TITLE
Fix Security Issues

### DIFF
--- a/src/main/java/io/jenkins/plugins/dotnet/DotNetConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/DotNetConfiguration.java
@@ -386,7 +386,7 @@ public class DotNetConfiguration extends GlobalConfiguration implements Serializ
       return FormValidation.ok();
     }
     final Jenkins jenkins = Jenkins.get();
-    jenkins.checkPermission(Jenkins.MANAGE);
+    jenkins.checkPermission(Jenkins.ADMINISTER);
     final int uses = jenkins.getAllItems(FreeStyleProject.class,
       project -> DotNetConfiguration.includesCommand(project, command)).size();
     if (uses == 0) {

--- a/src/main/java/io/jenkins/plugins/dotnet/DotNetSDKInstaller.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/DotNetSDKInstaller.java
@@ -205,7 +205,7 @@ public final class DotNetSDKInstaller extends ToolInstaller {
     @NonNull
     @POST
     public AutoCompletionCandidates doAutoCompleteLabel(@CheckForNull @QueryParameter String value) {
-      Jenkins.get().checkPermission(Jenkins.MANAGE);
+      Jenkins.get().checkPermission(Jenkins.ADMINISTER);
       return LabelExpression.autoComplete(value);
     }
 
@@ -219,7 +219,7 @@ public final class DotNetSDKInstaller extends ToolInstaller {
     @NonNull
     @POST
     public FormValidation doCheckLabel(@CheckForNull @QueryParameter String value) {
-      Jenkins.get().checkPermission(Jenkins.MANAGE);
+      Jenkins.get().checkPermission(Jenkins.ADMINISTER);
       return LabelExpression.validate(value, null);
     }
 
@@ -234,7 +234,7 @@ public final class DotNetSDKInstaller extends ToolInstaller {
     @NonNull
     @POST
     public FormValidation doCheckRelease(@CheckForNull @QueryParameter String version, @CheckForNull @QueryParameter String value) {
-      Jenkins.get().checkPermission(Jenkins.MANAGE);
+      Jenkins.get().checkPermission(Jenkins.ADMINISTER);
       if (Util.fixEmpty(version) == null)
         return FormValidation.error(Messages.DotNetSDKInstaller_VersionRequired());
       if (Util.fixEmpty(value) == null)
@@ -261,7 +261,7 @@ public final class DotNetSDKInstaller extends ToolInstaller {
     @POST
     public FormValidation doCheckSdk(@CheckForNull @QueryParameter String version, @CheckForNull @QueryParameter String release,
                                      @CheckForNull @QueryParameter String value) {
-      Jenkins.get().checkPermission(Jenkins.MANAGE);
+      Jenkins.get().checkPermission(Jenkins.ADMINISTER);
       if (Util.fixEmpty(version) == null)
         return FormValidation.error(Messages.DotNetSDKInstaller_VersionRequired());
       if (Util.fixEmpty(release) == null)
@@ -290,7 +290,7 @@ public final class DotNetSDKInstaller extends ToolInstaller {
     @POST
     public FormValidation doCheckUrl(@CheckForNull @QueryParameter String version, @CheckForNull @QueryParameter String release,
                                      @CheckForNull @QueryParameter String sdk, @CheckForNull @QueryParameter String value) {
-      Jenkins.get().checkPermission(Jenkins.MANAGE);
+      Jenkins.get().checkPermission(Jenkins.ADMINISTER);
       if (Util.fixEmpty(version) == null)
         return FormValidation.error(Messages.DotNetSDKInstaller_VersionRequired());
       if (Util.fixEmpty(release) == null)
@@ -315,7 +315,7 @@ public final class DotNetSDKInstaller extends ToolInstaller {
     @NonNull
     @POST
     public FormValidation doCheckVersion(@CheckForNull @QueryParameter String value) {
-      Jenkins.get().checkPermission(Jenkins.MANAGE);
+      Jenkins.get().checkPermission(Jenkins.ADMINISTER);
       if (Util.fixEmpty(value) == null)
         return FormValidation.error(Messages.DotNetSDKInstaller_Required());
       if (Downloads.getInstance().getVersion(value) == null)
@@ -333,7 +333,7 @@ public final class DotNetSDKInstaller extends ToolInstaller {
     @NonNull
     @POST
     public ListBoxModel doFillUrlItems(@CheckForNull @QueryParameter String sdk) {
-      Jenkins.get().checkPermission(Jenkins.MANAGE);
+      Jenkins.get().checkPermission(Jenkins.ADMINISTER);
       return Downloads.getInstance().addPackages(this.createList(), sdk);
     }
 
@@ -348,7 +348,7 @@ public final class DotNetSDKInstaller extends ToolInstaller {
     @NonNull
     @POST
     public ListBoxModel doFillReleaseItems(@CheckForNull @QueryParameter String version, @QueryParameter boolean includePreview) {
-      Jenkins.get().checkPermission(Jenkins.MANAGE);
+      Jenkins.get().checkPermission(Jenkins.ADMINISTER);
       return Downloads.getInstance().addReleases(this.createList(), version, includePreview);
     }
 
@@ -363,7 +363,7 @@ public final class DotNetSDKInstaller extends ToolInstaller {
     @NonNull
     @POST
     public ListBoxModel doFillSdkItems(@CheckForNull @QueryParameter String version, @CheckForNull @QueryParameter String release) {
-      Jenkins.get().checkPermission(Jenkins.MANAGE);
+      Jenkins.get().checkPermission(Jenkins.ADMINISTER);
       return Downloads.getInstance().addSdks(this.createList(), version, release);
     }
 
@@ -375,7 +375,7 @@ public final class DotNetSDKInstaller extends ToolInstaller {
     @NonNull
     @POST
     public ListBoxModel doFillVersionItems() {
-      Jenkins.get().checkPermission(Jenkins.MANAGE);
+      Jenkins.get().checkPermission(Jenkins.ADMINISTER);
       return Downloads.getInstance().addVersions(this.createList());
     }
 

--- a/src/main/java/io/jenkins/plugins/dotnet/DotNetWrapper.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/DotNetWrapper.java
@@ -13,7 +13,6 @@ import hudson.model.AbstractProject;
 import hudson.model.Item;
 import hudson.model.Run;
 import hudson.model.TaskListener;
-import hudson.security.Permission;
 import hudson.tasks.BuildWrapperDescriptor;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
@@ -177,8 +176,10 @@ public class DotNetWrapper extends SimpleBuildWrapper {
      */
     @NonNull
     @POST
-    public FormValidation doCheckSdk(@CheckForNull @QueryParameter String value, @NonNull @AncestorInPath Item item) {
-      item.checkPermission(Permission.CONFIGURE);
+    public FormValidation doCheckSdk(@CheckForNull @QueryParameter String value, @CheckForNull @AncestorInPath Item item) {
+      if (item != null) {
+        item.checkPermission(Item.CONFIGURE);
+      }
       return FormValidation.validateRequired(value);
     }
 
@@ -191,8 +192,10 @@ public class DotNetWrapper extends SimpleBuildWrapper {
      */
     @NonNull
     @POST
-    public ListBoxModel doFillSdkItems(@NonNull @AncestorInPath Item item) {
-      item.checkPermission(Permission.CONFIGURE);
+    public ListBoxModel doFillSdkItems(@CheckForNull @AncestorInPath Item item) {
+      if (item != null) {
+        item.checkPermission(Item.CONFIGURE);
+      }
       final ListBoxModel model = new ListBoxModel();
       DotNetSDK.addSdks(model);
       return model;

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/CommandDescriptor.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/CommandDescriptor.java
@@ -8,7 +8,6 @@ import hudson.model.AbstractProject;
 import hudson.model.AutoCompletionCandidates;
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
-import hudson.security.Permission;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.util.FormValidation;
@@ -59,7 +58,7 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
   public final AutoCompletionCandidates doAutoCompleteFramework(@CheckForNull @QueryParameter String value,
                                                                 @CheckForNull @AncestorInPath Item item) {
     if (item != null) {
-      item.checkPermission(Permission.CONFIGURE);
+      item.checkPermission(Item.CONFIGURE);
     }
     return Framework.getInstance().autoCompleteMoniker(value);
   }
@@ -77,7 +76,7 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
   public final AutoCompletionCandidates doAutoCompleteFrameworksString(@CheckForNull @QueryParameter String value,
                                                                        @CheckForNull @AncestorInPath Item item) {
     if (item != null) {
-      item.checkPermission(Permission.CONFIGURE);
+      item.checkPermission(Item.CONFIGURE);
     }
     return Framework.getInstance().autoCompleteMoniker(value);
   }
@@ -95,7 +94,7 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
   public final AutoCompletionCandidates doAutoCompleteRuntime(@CheckForNull @QueryParameter String value,
                                                               @CheckForNull @AncestorInPath Item item) {
     if (item != null) {
-      item.checkPermission(Permission.CONFIGURE);
+      item.checkPermission(Item.CONFIGURE);
     }
     return Runtime.getInstance().autoCompleteIdentifier(value);
   }
@@ -113,7 +112,7 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
   public final AutoCompletionCandidates doAutoCompleteRuntimesString(@CheckForNull @QueryParameter String value,
                                                                      @CheckForNull @AncestorInPath Item item) {
     if (item != null) {
-      item.checkPermission(Permission.CONFIGURE);
+      item.checkPermission(Item.CONFIGURE);
     }
     return Runtime.getInstance().autoCompleteIdentifier(value);
   }
@@ -130,7 +129,7 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
   @POST
   public FormValidation doCheckCharset(@CheckForNull @QueryParameter String value, @CheckForNull @AncestorInPath Item item) {
     if (item != null) {
-      item.checkPermission(Permission.CONFIGURE);
+      item.checkPermission(Item.CONFIGURE);
     }
     final String name = Util.fixEmptyAndTrim(value);
     if (name != null) {
@@ -156,7 +155,7 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
   @POST
   public FormValidation doCheckFramework(@CheckForNull @QueryParameter String value, @CheckForNull @AncestorInPath Item item) {
     if (item != null) {
-      item.checkPermission(Permission.CONFIGURE);
+      item.checkPermission(Item.CONFIGURE);
     }
     return Framework.getInstance().checkMoniker(value);
   }
@@ -173,7 +172,7 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
   @POST
   public FormValidation doCheckFrameworksString(@CheckForNull @QueryParameter String value, @CheckForNull @AncestorInPath Item item) {
     if (item != null) {
-      item.checkPermission(Permission.CONFIGURE);
+      item.checkPermission(Item.CONFIGURE);
     }
     return Framework.getInstance().checkMonikers(value);
   }
@@ -190,7 +189,7 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
   @POST
   public FormValidation doCheckRuntime(@CheckForNull @QueryParameter String value, @CheckForNull @AncestorInPath Item item) {
     if (item != null) {
-      item.checkPermission(Permission.CONFIGURE);
+      item.checkPermission(Item.CONFIGURE);
     }
     return Runtime.getInstance().checkIdentifier(value);
   }
@@ -207,7 +206,7 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
   @POST
   public FormValidation doCheckRuntimesString(@CheckForNull @QueryParameter String value, @CheckForNull @AncestorInPath Item item) {
     if (item != null) {
-      item.checkPermission(Permission.CONFIGURE);
+      item.checkPermission(Item.CONFIGURE);
     }
     return Runtime.getInstance().checkIdentifiers(value);
   }
@@ -223,7 +222,7 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
   @POST
   public final ListBoxModel doFillCharsetItems(@CheckForNull @AncestorInPath Item item) {
     if (item != null) {
-      item.checkPermission(Permission.CONFIGURE);
+      item.checkPermission(Item.CONFIGURE);
     }
     final ListBoxModel model = new ListBoxModel();
     model.add(Messages.Command_SameCharsetAsBuild(), "");
@@ -251,7 +250,7 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
   @POST
   public final ListBoxModel doFillSdkItems(@CheckForNull @AncestorInPath Item item) {
     if (item != null) {
-      item.checkPermission(Permission.CONFIGURE);
+      item.checkPermission(Item.CONFIGURE);
     }
     final ListBoxModel model = new ListBoxModel();
     model.add(Messages.Command_DefaultSDK(), "");
@@ -270,7 +269,7 @@ public abstract class CommandDescriptor extends BuildStepDescriptor<Builder> imp
   @POST
   public final ListBoxModel doFillVerbosityItems(@CheckForNull @AncestorInPath Item item) {
     if (item != null) {
-      item.checkPermission(Permission.CONFIGURE);
+      item.checkPermission(Item.CONFIGURE);
     }
     final ListBoxModel model = new ListBoxModel();
     model.add(Messages.Command_Verbosity_Default(), "");

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/ListPackage.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/ListPackage.java
@@ -5,7 +5,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.Item;
-import hudson.security.Permission;
 import hudson.util.FormValidation;
 import io.jenkins.plugins.dotnet.DotNetConfiguration;
 import io.jenkins.plugins.dotnet.DotNetUtils;
@@ -478,7 +477,7 @@ public final class ListPackage extends Command {
     public FormValidation doCheckConfig(@CheckForNull @QueryParameter String value, @QueryParameter boolean deprecated,
                                         @QueryParameter boolean outdated, @CheckForNull @AncestorInPath Item item) {
       if (item != null) {
-        item.checkPermission(Permission.CONFIGURE);
+        item.checkPermission(Item.CONFIGURE);
       }
       if (Util.fixEmptyAndTrim(value) != null && !deprecated && !outdated) {
         return FormValidation.warning(Messages.ListPackage_OnlyForPackageUpdateSearch());
@@ -500,7 +499,7 @@ public final class ListPackage extends Command {
     public FormValidation doCheckDeprecated(@QueryParameter boolean deprecated, @QueryParameter boolean outdated,
                                             @CheckForNull @AncestorInPath Item item) {
       if (item != null) {
-        item.checkPermission(Permission.CONFIGURE);
+        item.checkPermission(Item.CONFIGURE);
       }
       if (deprecated && outdated) {
         return FormValidation.error(Messages.ListPackage_EitherDeprecatedOrOutdated());
@@ -523,7 +522,7 @@ public final class ListPackage extends Command {
     public FormValidation doCheckHighestMinor(@QueryParameter boolean value, @QueryParameter boolean deprecated,
                                               @QueryParameter boolean outdated, @CheckForNull @AncestorInPath Item item) {
       if (item != null) {
-        item.checkPermission(Permission.CONFIGURE);
+        item.checkPermission(Item.CONFIGURE);
       }
       if (value && !deprecated && !outdated) {
         return FormValidation.warning(Messages.ListPackage_OnlyForPackageUpdateSearch());
@@ -546,7 +545,7 @@ public final class ListPackage extends Command {
     public FormValidation doCheckHighestPatch(@QueryParameter boolean value, @QueryParameter boolean deprecated,
                                               @QueryParameter boolean outdated, @CheckForNull @AncestorInPath Item item) {
       if (item != null) {
-        item.checkPermission(Permission.CONFIGURE);
+        item.checkPermission(Item.CONFIGURE);
       }
       if (value && !deprecated && !outdated) {
         return FormValidation.warning(Messages.ListPackage_OnlyForPackageUpdateSearch());
@@ -569,7 +568,7 @@ public final class ListPackage extends Command {
     public FormValidation doCheckIncludePrerelease(@QueryParameter boolean value, @QueryParameter boolean deprecated,
                                                    @QueryParameter boolean outdated, @CheckForNull @AncestorInPath Item item) {
       if (item != null) {
-        item.checkPermission(Permission.CONFIGURE);
+        item.checkPermission(Item.CONFIGURE);
       }
       if (value && !deprecated && !outdated) {
         return FormValidation.warning(Messages.ListPackage_OnlyForPackageUpdateSearch());
@@ -591,7 +590,7 @@ public final class ListPackage extends Command {
     public FormValidation doCheckOutdated(@QueryParameter boolean deprecated, @QueryParameter boolean outdated,
                                           @CheckForNull @AncestorInPath Item item) {
       if (item != null) {
-        item.checkPermission(Permission.CONFIGURE);
+        item.checkPermission(Item.CONFIGURE);
       }
       if (deprecated && outdated) {
         return FormValidation.error(Messages.ListPackage_EitherDeprecatedOrOutdated());
@@ -614,7 +613,7 @@ public final class ListPackage extends Command {
     public FormValidation doCheckSourcesString(@CheckForNull @QueryParameter String value, @QueryParameter boolean deprecated,
                                                @QueryParameter boolean outdated, @CheckForNull @AncestorInPath Item item) {
       if (item != null) {
-        item.checkPermission(Permission.CONFIGURE);
+        item.checkPermission(Item.CONFIGURE);
       }
       if (Util.fixEmptyAndTrim(value) != null && !deprecated && !outdated) {
         return FormValidation.warning(Messages.ListPackage_OnlyForPackageUpdateSearch());

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/MSBuildCommandDescriptor.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/MSBuildCommandDescriptor.java
@@ -4,7 +4,6 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Util;
 import hudson.model.Item;
-import hudson.security.Permission;
 import hudson.util.ComboBoxModel;
 import hudson.util.FormValidation;
 import io.jenkins.plugins.dotnet.commands.CommandDescriptor;
@@ -50,7 +49,7 @@ public abstract class MSBuildCommandDescriptor extends CommandDescriptor {
   @POST
   public FormValidation doCheckPropertiesString(@QueryParameter String value, @CheckForNull @AncestorInPath Item item) {
     if (item != null) {
-      item.checkPermission(Permission.CONFIGURE);
+      item.checkPermission(Item.CONFIGURE);
     }
     value = Util.fixEmptyAndTrim(value);
     if (value != null) {
@@ -75,7 +74,7 @@ public abstract class MSBuildCommandDescriptor extends CommandDescriptor {
   @POST
   public final ComboBoxModel doFillConfigurationItems(@CheckForNull @AncestorInPath Item item) {
     if (item != null) {
-      item.checkPermission(Permission.CONFIGURE);
+      item.checkPermission(Item.CONFIGURE);
     }
     final ComboBoxModel model = new ComboBoxModel();
     // Note: not localized

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Publish.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Publish.java
@@ -5,7 +5,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.Item;
-import hudson.security.Permission;
 import hudson.util.ListBoxModel;
 import io.jenkins.plugins.dotnet.DotNetConfiguration;
 import io.jenkins.plugins.dotnet.DotNetUtils;
@@ -346,7 +345,7 @@ public final class Publish extends MSBuildCommand {
     @POST
     public ListBoxModel doFillSelfContainedItems(@CheckForNull @AncestorInPath Item item) {
       if (item != null) {
-        item.checkPermission(Permission.CONFIGURE);
+        item.checkPermission(Item.CONFIGURE);
       }
       final ListBoxModel model = new ListBoxModel();
       model.add(Messages.MSBuild_Publish_ProjectDefault(), null);

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Test.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/msbuild/Test.java
@@ -5,7 +5,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.Item;
-import hudson.security.Permission;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import io.jenkins.plugins.dotnet.DotNetConfiguration;
@@ -605,7 +604,7 @@ public final class Test extends MSBuildCommand {
     public FormValidation doCheckBlameHangTimeout(@CheckForNull @QueryParameter Integer value,
                                                   @CheckForNull @AncestorInPath Item item) {
       if (item != null) {
-        item.checkPermission(Permission.CONFIGURE);
+        item.checkPermission(Item.CONFIGURE);
       }
       if (value == null) {
         return FormValidation.ok();
@@ -646,7 +645,7 @@ public final class Test extends MSBuildCommand {
     public FormValidation doCheckRunSettingsString(@CheckForNull @QueryParameter String value,
                                                    @CheckForNull @AncestorInPath Item item) {
       if (item != null) {
-        item.checkPermission(Permission.CONFIGURE);
+        item.checkPermission(Item.CONFIGURE);
       }
       value = Util.fixEmptyAndTrim(value);
       if (value != null) {
@@ -671,7 +670,7 @@ public final class Test extends MSBuildCommand {
     @POST
     public ListBoxModel doFillBlameCrashDumpTypeItems(@CheckForNull @AncestorInPath Item item) {
       if (item != null) {
-        item.checkPermission(Permission.CONFIGURE);
+        item.checkPermission(Item.CONFIGURE);
       }
       final ListBoxModel model = new ListBoxModel();
       model.add("");
@@ -691,7 +690,7 @@ public final class Test extends MSBuildCommand {
     @POST
     public ListBoxModel doFillBlameHangDumpTypeItems(@CheckForNull @AncestorInPath Item item) {
       if (item != null) {
-        item.checkPermission(Permission.CONFIGURE);
+        item.checkPermission(Item.CONFIGURE);
       }
       final ListBoxModel model = new ListBoxModel();
       model.add("");

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/nuget/Delete.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/nuget/Delete.java
@@ -6,7 +6,6 @@ import hudson.AbortException;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.Item;
-import hudson.security.Permission;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import io.jenkins.plugins.dotnet.DotNetConfiguration;
@@ -95,7 +94,7 @@ public final class Delete extends DeleteOrPush {
     @POST
     public FormValidation doCheckPackageName(@CheckForNull @QueryParameter String value, @CheckForNull @AncestorInPath Item item) {
       if (item != null) {
-        item.checkPermission(Permission.CONFIGURE);
+        item.checkPermission(Item.CONFIGURE);
       }
       value = Util.fixEmptyAndTrim(value);
       if (value != null && value.split(" \r\t\n", 2).length != 1) {
@@ -119,7 +118,7 @@ public final class Delete extends DeleteOrPush {
                                                 @CheckForNull @QueryParameter String packageName,
                                                 @CheckForNull @AncestorInPath Item item) {
       if (item != null) {
-        item.checkPermission(Permission.CONFIGURE);
+        item.checkPermission(Item.CONFIGURE);
       }
       value = Util.fixEmptyAndTrim(value);
       if (value != null && value.split(" \r\t\n", 2).length != 1) {
@@ -147,7 +146,7 @@ public final class Delete extends DeleteOrPush {
     @POST
     public ListBoxModel doFillApiKeyIdItems(@CheckForNull @AncestorInPath Item item) {
       if (item != null) {
-        item.checkPermission(Permission.CONFIGURE);
+        item.checkPermission(Item.CONFIGURE);
       }
       return DotNetUtils.getStringCredentialsList(true);
     }

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/nuget/Locals.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/nuget/Locals.java
@@ -5,7 +5,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.AbortException;
 import hudson.Extension;
 import hudson.model.Item;
-import hudson.security.Permission;
 import hudson.util.ListBoxModel;
 import io.jenkins.plugins.dotnet.DotNetConfiguration;
 import io.jenkins.plugins.dotnet.commands.DotNetArguments;
@@ -113,7 +112,7 @@ public final class Locals extends NuGetCommand {
     @POST
     public ListBoxModel doFillCacheLocationItems(@CheckForNull @AncestorInPath Item item) {
       if (item != null) {
-        item.checkPermission(Permission.CONFIGURE);
+        item.checkPermission(Item.CONFIGURE);
       }
       final ListBoxModel model = new ListBoxModel();
       model.add(Messages.NuGet_Locals_Location_All(), Locals.LOCATION_ALL);
@@ -134,7 +133,7 @@ public final class Locals extends NuGetCommand {
     @POST
     public ListBoxModel doFillOperationItems(@CheckForNull @AncestorInPath Item item) {
       if (item != null) {
-        item.checkPermission(Permission.CONFIGURE);
+        item.checkPermission(Item.CONFIGURE);
       }
       final ListBoxModel model = new ListBoxModel();
       model.add(Messages.NuGet_Locals_Operation_Clear(), Locals.OPERATION_CLEAR);

--- a/src/main/java/io/jenkins/plugins/dotnet/commands/nuget/Push.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/commands/nuget/Push.java
@@ -6,7 +6,6 @@ import hudson.AbortException;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.Item;
-import hudson.security.Permission;
 import hudson.util.ListBoxModel;
 import io.jenkins.plugins.dotnet.DotNetConfiguration;
 import io.jenkins.plugins.dotnet.DotNetUtils;
@@ -183,7 +182,7 @@ public final class Push extends DeleteOrPush {
     @POST
     public ListBoxModel doFillApiKeyIdItems(@CheckForNull @AncestorInPath Item item) {
       if (item != null) {
-        item.checkPermission(Permission.CONFIGURE);
+        item.checkPermission(Item.CONFIGURE);
       }
       return DotNetUtils.getStringCredentialsList(true);
     }
@@ -199,7 +198,7 @@ public final class Push extends DeleteOrPush {
     @POST
     public ListBoxModel doFillSymbolApiKeyIdItems(@CheckForNull @AncestorInPath Item item) {
       if (item != null) {
-        item.checkPermission(Permission.CONFIGURE);
+        item.checkPermission(Item.CONFIGURE);
       }
       return DotNetUtils.getStringCredentialsList(true);
     }


### PR DESCRIPTION
This switches the permissions checks:
- the simple ones now use `Item.CONFIGURE` instead of `Permission.CONFIGURE`
  - this should resolve the issues complaining about needing "N/A/GenericConfigure"
- the ones related to the tool setup now use `Jenkins.ADMINISTER` instead of `Jenkins.MANAGE`
