### PR TITLE
JENKINS-68729: Abort the build on error

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -63,9 +63,4 @@
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
-  <component name="SwUserDefinedSpecifications">
-    <option name="specTypeByUrl">
-      <map />
-    </option>
-  </component>
 </project>

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/Command/help-continueOnError.html
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/Command/help-continueOnError.html
@@ -1,0 +1,5 @@
+<div>
+  If this is checked, errors encountered will cause the build status to be set to <code>FAILURE</code> (or <code>UNSTABLE</code>, if
+  configured that way), but the build will be allowed to continue. Otherwise, any such errors will cause the build to be terminated
+  immediately.
+</div>

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/Command/options.jelly
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/Command/options.jelly
@@ -5,4 +5,8 @@
     <f:textbox/>
   </f:entry>
 
+  <f:entry title="${%Continue On Error}" field="continueOnError">
+    <f:checkbox/>
+  </f:entry>
+
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/Command/options_fr.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/Command/options_fr.properties
@@ -1,1 +1,2 @@
+Continue\ On\ Error=Continuer en cas d'erreurs
 Work\ Directory=Dossier de travail

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/Command/options_nl.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/Command/options_nl.properties
@@ -1,1 +1,2 @@
+Continue\ On\ Error=Doorgaan bij fouten
 Work\ Directory=Werkfolder

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/Messages.properties
@@ -1,5 +1,7 @@
 Command.DefaultSDK=(Default)
-Command.ExecutionFailed=Command execution failed
+Command.ExecutionCompletedWithErrors=Command execution completed with {0} error(s).
+Command.ExecutionCompletedWithNonZeroReturnCode=Command execution completed with return code {0}.
+Command.ExecutionFailed=Command execution failed.
 Command.MoreOptions=More Options
 Command.SameCharsetAsBuild=<Same As Rest of Build>
 Command.UnsupportedCharset=Unsupported character set

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/Messages_fr.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/Messages_fr.properties
@@ -1,5 +1,7 @@
 Command.DefaultSDK=(Défaut)
-Command.ExecutionFailed=L'exécution de l'ordre a échoué
+Command.ExecutionCompletedWithErrors=Exécution de l'ordre terminée avec {0} erreur(s).
+Command.ExecutionCompletedWithNonZeroReturnCode=Exécution de l'ordre terminée avec code de retour {0}.
+Command.ExecutionFailed=L'exécution de l'ordre a échoué.
 Command.MoreOptions=Options additionnelles
 Command.SameCharsetAsBuild=Identique au reste du build
 Command.UnsupportedCharset=Jeu de caractères non supporté

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/Messages_nl.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/Messages_nl.properties
@@ -1,5 +1,7 @@
 Command.DefaultSDK=(Standaard)
-Command.ExecutionFailed=Uitvoeren van commando mislukt
+Command.ExecutionCompletedWithErrors=Uitvoeren van commando beëindigd met {0} fout(en).
+Command.ExecutionCompletedWithNonZeroReturnCode=Uitvoeren van commando beëindigd met code {0}.
+Command.ExecutionFailed=Uitvoeren van commando mislukt.
 Command.MoreOptions=Meer opties
 Command.SameCharsetAsBuild=<Hetzelfde als de rest van de build>
 Command.UnsupportedCharset=Deze tekenset wordt niet ondersteund

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/msbuild/MSBuildCommand/help-unstableIfErrors.html
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/msbuild/MSBuildCommand/help-unstableIfErrors.html
@@ -1,3 +1,4 @@
 <div>
-  If this is set and the build completes with errors, the build will be marked as unstable instead of failed.
+  If this is set and the build completes with errors, the build will be marked as unstable instead of failed, and execution will
+  continue to the next step.
 </div>

--- a/src/main/resources/io/jenkins/plugins/dotnet/commands/msbuild/MSBuildCommand/options.jelly
+++ b/src/main/resources/io/jenkins/plugins/dotnet/commands/msbuild/MSBuildCommand/options.jelly
@@ -1,11 +1,11 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:s="jelly:stapler">
 
-  <s:include page="options.jelly" class="io.jenkins.plugins.dotnet.commands.Command"/>
-
   <f:entry title="${%Configuration}" field="configuration">
     <f:combobox/>
   </f:entry>
+
+  <s:include page="options.jelly" class="io.jenkins.plugins.dotnet.commands.Command"/>
 
   <f:entry title="${%Errors Result in Unstable Build}" field="unstableIfErrors">
     <f:checkbox/>


### PR DESCRIPTION
[JENKINS-68729](https://issues.jenkins.io/browse/JENKINS-68729)

Previously, when there were errors (either reported by a build, or a non-zero return code), the build was marked as failed, but continued to the next step.

Now, such errors will cause the build to be aborted.

A new "Continue On Error" option has been added to provide the old behaviour. However, it was _not_ made the default; this may break compatibility with any existing builds that rely on the old behaviour.
