### PR TITLE
Disable multi-level lookup

### DIFF
--- a/src/main/java/io/jenkins/plugins/dotnet/DotNetSDK.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/DotNetSDK.java
@@ -132,6 +132,8 @@ public final class DotNetSDK extends ToolInstallation implements NodeSpecific<Do
     if (this.configuration.isTelemetryOptOut() || this.telemetryOptOut) {
       env.put("DOTNET_CLI_TELEMETRY_OPTOUT", "1");
     }
+    // Without this, a more recent system-level SDK can get used (especially on Windows) instead of the configured one.
+    env.put("DOTNET_MULTILEVEL_LOOKUP", "0");
   }
 
   /**


### PR DESCRIPTION
This will set the `DOTNET_MULTILEVEL_LOOKUP` environment variable to `0` when using an explicitly configured SDK.

Without this, a more recent system-level SDK can get used (especially on Windows) instead of the configured one (even with `PATH` and `DOTNET_ROOT` set appropriately).
