### PR TITLE
Update the handling for SDK versions

### DIFF
--- a/src/main/java/io/jenkins/plugins/dotnet/data/Framework.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/data/Framework.java
@@ -38,8 +38,9 @@ public final class Framework extends DownloadService.Downloadable {
   public AutoCompletionCandidates autoCompleteMoniker(@CheckForNull String text) {
     final AutoCompletionCandidates candidates = new AutoCompletionCandidates();
     for (final String tfm : this.monikers) {
-      if (text == null || tfm.startsWith(text))
+      if (text == null || tfm.startsWith(text)) {
         candidates.add(tfm);
+      }
     }
     return candidates;
   }
@@ -55,8 +56,9 @@ public final class Framework extends DownloadService.Downloadable {
   public FormValidation checkMoniker(@CheckForNull String text) {
     text = Util.fixEmptyAndTrim(text);
     if (text != null) {
-      if (!this.monikers.contains(text))
-        return FormValidation.error(Messages.Framework_Invalid(text));
+      if (!this.monikers.contains(text)) {
+        return FormValidation.warning(Messages.Framework_Invalid(text));
+      }
     }
     return FormValidation.ok();
   }
@@ -71,13 +73,15 @@ public final class Framework extends DownloadService.Downloadable {
   @NonNull
   public FormValidation checkMonikers(@CheckForNull String text) {
     text = Util.fixEmptyAndTrim(text);
-    if (text == null)
+    if (text == null) {
       return FormValidation.ok();
+    }
     final List<FormValidation> result = new ArrayList<>();
     for (final String runtime : Util.tokenize(text)) {
       final FormValidation fv = this.checkMoniker(runtime);
-      if (fv.kind != FormValidation.Kind.OK)
+      if (fv.kind != FormValidation.Kind.OK) {
         result.add(fv);
+      }
     }
     return FormValidation.aggregate(result);
   }

--- a/src/main/java/io/jenkins/plugins/dotnet/data/Runtime.java
+++ b/src/main/java/io/jenkins/plugins/dotnet/data/Runtime.java
@@ -38,8 +38,9 @@ public final class Runtime extends DownloadService.Downloadable {
   public AutoCompletionCandidates autoCompleteIdentifier(@CheckForNull String text) {
     final AutoCompletionCandidates candidates = new AutoCompletionCandidates();
     for (final String rid : this.identifiers) {
-      if (text == null || rid.startsWith(text))
+      if (text == null || rid.startsWith(text)) {
         candidates.add(rid);
+      }
     }
     return candidates;
   }
@@ -55,8 +56,9 @@ public final class Runtime extends DownloadService.Downloadable {
   public FormValidation checkIdentifier(@CheckForNull String text) {
     text = Util.fixEmptyAndTrim(text);
     if (text != null) {
-      if (!this.identifiers.contains(text))
-        return FormValidation.error(Messages.Runtime_Invalid(text));
+      if (!this.identifiers.contains(text)) {
+        return FormValidation.warning(Messages.Runtime_Invalid(text));
+      }
     }
     return FormValidation.ok();
   }
@@ -71,13 +73,15 @@ public final class Runtime extends DownloadService.Downloadable {
   @NonNull
   public FormValidation checkIdentifiers(@CheckForNull String text) {
     text = Util.fixEmptyAndTrim(text);
-    if (text == null)
+    if (text == null) {
       return FormValidation.ok();
+    }
     final List<FormValidation> result = new ArrayList<>();
     for (final String runtime : Util.tokenize(text)) {
       final FormValidation fv = this.checkIdentifier(runtime);
-      if (fv.kind != FormValidation.Kind.OK)
+      if (fv.kind != FormValidation.Kind.OK) {
         result.add(fv);
+      }
     }
     return FormValidation.aggregate(result);
   }

--- a/src/main/resources/io/jenkins/plugins/dotnet/data/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/data/Messages.properties
@@ -10,6 +10,9 @@ Downloads.Sdk.DisplayName={0}
 Downloads.Unknown=???
 Downloads.Version.DisplayName={0} - {1}
 Downloads.Version.DisplayNameWithDate={0} - {1} (end of support: {2})
+Downloads.Version.DisplayNameWithType={0} - {1} ({2})
+Downloads.Version.DisplayNameWithTypeAndDate={0} - {1} ({2}; end of support: {3})
+Downloads.Version.Status.Active=Active
 Downloads.Version.Status.Current=Current
 Downloads.Version.Status.EOL=End of Life
 Downloads.Version.Status.LTS=Long-Term Support
@@ -17,13 +20,16 @@ Downloads.Version.Status.Maintenance=Maintenance
 Downloads.Version.Status.Preview=Preview
 Downloads.Version.Status.ReleaseCandidate=Release Candidate
 Downloads.Version.Status.Unknown=Status Unknown
+Downloads.Version.Type.STS=Short-Term Support
+Downloads.Version.Type.LTS=Long-Term Support
+Downloads.Version.Type.Unknown=Unknown
 
 # Data: Framework Monikers
-Framework.Invalid="{0}" is not a valid .NET framework moniker
+Framework.Invalid="{0}" is not a known .NET framework moniker
 Framework.LoadFailed=Failed to load the .NET framework monikers.
 Framework.NoData=No .NET framework monikers found.
 
 # Data: Runtime Identifiers
-Runtime.Invalid="{0}" is not a valid .NET runtime identifier
+Runtime.Invalid="{0}" is not a known .NET runtime identifier
 Runtime.LoadFailed=Failed to load RID catalog.
 Runtime.NoData=RID catalog is empty.

--- a/src/main/resources/io/jenkins/plugins/dotnet/data/Messages_fr.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/data/Messages_fr.properties
@@ -10,6 +10,9 @@ Downloads.Sdk.DisplayName={0}
 Downloads.Unknown=???
 Downloads.Version.DisplayName={0} - {1}
 Downloads.Version.DisplayNameWithDate={0} - {1} (fin du soutien: {2})
+Downloads.Version.DisplayNameWithType={0} - {1} ({2})
+Downloads.Version.DisplayNameWithTypeAndDate={0} - {1} ({2}; fin du soutien: {3})
+Downloads.Version.Status.Active=Actif
 Downloads.Version.Status.Current=Courant
 Downloads.Version.Status.EOL=Fin de vie
 Downloads.Version.Status.LTS=Soutien à long terme
@@ -17,13 +20,16 @@ Downloads.Version.Status.Maintenance=Entretien
 Downloads.Version.Status.Preview=Aperçu
 Downloads.Version.Status.ReleaseCandidate=Release Candidate
 Downloads.Version.Status.Unknown=Statut inconnu
+Downloads.Version.Type.STS=Soutien à court terme
+Downloads.Version.Type.LTS=Soutien à long terme
+Downloads.Version.Type.Unknown=Inconnu
 
 # Data: Framework Monikers
-Framework.Invalid=«{0}» n'est pas un surnom de framework .NET valide
+Framework.Invalid=«{0}» n'est pas un surnom de framework .NET connu
 Framework.LoadFailed=Échec à charger les surnoms de framework .NET.
 Framework.NoData=Aucun surnom de framework .NET trouvé.
 
 # Data: Runtime Identifiers
-Runtime.Invalid=«{0}» n'est pas un identifiant de runtime .NET valide
+Runtime.Invalid=«{0}» n'est pas un identifiant de runtime .NET connu
 Runtime.LoadFailed=Échec à charger le catalogue RID.
 Runtime.NoData=Le catalogue RID est vide.

--- a/src/main/resources/io/jenkins/plugins/dotnet/data/Messages_nl.properties
+++ b/src/main/resources/io/jenkins/plugins/dotnet/data/Messages_nl.properties
@@ -1,6 +1,6 @@
 # Data: Downloads
-Downloads.NoSdks=Geen .NET SDK informatie beschikbaar
-Downloads.NoVersions=Geen .NET versie-informatie beschikbaar
+Downloads.NoSdks=Geen informatie beschikbaar over .NET SDKs
+Downloads.NoVersions=Geen informatie beschikbaar over .NET SDK versies
 Downloads.Package.DirectDownloadLink=<a href="{0}">Rechtstreekse Download</a>
 Downloads.Package.DisplayName={0} ({1})
 Downloads.Release.DisplayName={0}, uitgebracht op {1}
@@ -10,20 +10,26 @@ Downloads.Sdk.DisplayName={0}
 Downloads.Unknown=???
 Downloads.Version.DisplayName={0} - {1}
 Downloads.Version.DisplayNameWithDate={0} - {1} (einde ondersteuning: {2})
+Downloads.Version.DisplayNameWithType={0} - {1} ({2})
+Downloads.Version.DisplayNameWithTypeAndDate={0} - {1} ({2}; einde ondersteuning: {3})
+Downloads.Version.Status.Active=Actief
 Downloads.Version.Status.Current=Current
-Downloads.Version.Status.EOL=End of life
-Downloads.Version.Status.LTS=Long-term support
+Downloads.Version.Status.EOL=End of Life
+Downloads.Version.Status.LTS=Long-Term Support
 Downloads.Version.Status.Maintenance=Maintenance
 Downloads.Version.Status.Preview=Preview
 Downloads.Version.Status.ReleaseCandidate=Release Candidate
 Downloads.Version.Status.Unknown=Status onbekend
+Downloads.Version.Type.STS=Short-Term Support
+Downloads.Version.Type.LTS=Long-Term Support
+Downloads.Version.Type.Unknown=Onbekend
 
 # Data: Framework Monikers
-Framework.Invalid="{0}" is geen geldige .NET framework-benaming
+Framework.Invalid="{0}" is geen gekende .NET framework-benaming
 Framework.LoadFailed=Laden van de .NET framework-benamingen mislukt.
 Framework.NoData=Geen .NET framework-benamingen gevonden.
 
 # Data: Runtime Identifiers
-Runtime.Invalid="{0}" is geen geldige .NET runtime-id
+Runtime.Invalid="{0}" is geen gekende .NET runtime-id
 Runtime.LoadFailed=Laden van RID-catalogus mislukt.
 Runtime.NoData=De RID-catalogus is leeg.


### PR DESCRIPTION
This handles the new status (ACTIVE) and sub-type (STS/LTS) for .NET SDKs.

This had been added only on the step-redesign branch, but because that is languishing a bit, it made sense to backport it to main.
